### PR TITLE
Downgrade frigate to 0.11.1

### DIFF
--- a/frigate/config.yml
+++ b/frigate/config.yml
@@ -3,6 +3,9 @@ mqtt:
   port: 1884
 cameras:
   doorbell:
+    # 0.11.1 workaround, disable rtmp otherwise crash at startup:
+    rtmp:
+      enabled: False
     ffmpeg:
       inputs:
         - path: rtsp://viewer:{FRIGATE_RTSP_PASSWORD}@192.168.2.151:554/h264Preview_01_sub
@@ -20,9 +23,15 @@ detectors:
     type: edgetpu
     device: usb
 
-# For some reason this does not meaningfully reduce cpu usage, to be investigated:
+# For some reason this does not meaningfully reduce cpu usage, to be investigated.
+# Apparently worked better with 0.11.1: https://github.com/blakeblackshear/frigate/issues/3780#issuecomment-1676078252
+# 0.12.0:
+#ffmpeg:
+#  hwaccel_args: preset-rpi-64-h264
+
+# 0.11.1:
 ffmpeg:
-  hwaccel_args: preset-rpi-64-h264
+  hwaccel_args: -c:v h264_v4l2m2m
 
 snapshots:
   enabled: True 

--- a/frigate/docker-compose.yml
+++ b/frigate/docker-compose.yml
@@ -4,7 +4,9 @@ services:
     container_name: frigate
     privileged: true # this may not be necessary for all setups
     restart: unless-stopped
-    image: ghcr.io/blakeblackshear/frigate:stable
+    # Old repo for versions pre 0.12; using this version for better h264 hwaccel support:
+    image: blakeblackshear/frigate:0.11.1
+    # image: ghcr.io/blakeblackshear/frigate:stable
     # update shm_size if there are more than 2 cameras at 720p, see: 
     # https://docs.frigate.video/frigate/installation#calculating-required-shm-size
     shm_size: "64mb" 


### PR DESCRIPTION
Testing hardware acceleration by downgrading to fridate 0.11.1. 
Doesn't seem like a meaningful difference...