### PR TITLE
Set constant temp for floor heating pump

### DIFF
--- a/home-assistant/config/automation/floor_heating_pump.yaml
+++ b/home-assistant/config/automation/floor_heating_pump.yaml
@@ -1,14 +1,26 @@
 - alias: "Floor Heating Pump toggle"
   id: floor-heating-pump-toggle
   trigger:
+    # TODO: Think of a better trigger that doesn't lead to log spam.
+    #       Want to use numeric_state on temperature, but fear it is
+    #       not reliable enough.
     - platform: time_pattern
-      seconds: 0
+      minutes: 5
+    - platform: home_assistant
+      event: start
   variables:
-    hour: "{{ now().hour }}"
-    temp: "{{ states('sensor.climate_living_room_temperature') | float }}"
-    # Hour <= 20 makes water flow until 20:59. Heat runs until 19:59. 1 hour to spread the heat.
-    turn_on_below: "{{ 19.25 if hour >= 5 and hour <= 20 else 18.75 }}"
-    turn_off_above: "{{ turn_on_below + 0.25 }}"
+    target_plus_offset: >-
+      {{ states('input_number.living_room_temperature_target') +
+         states('input_number.living_room_temperature_pump_offset')
+      }}
+    margin: >-
+      {{ states('input_number.living_room_temperature_pump_margin') }}
+    temp: >-
+      # The default of 0 makes the pump always go on if the sensor is dead, which is useful to
+      # ensure continuation of service:
+      {{ states('sensor.climate_living_room_temperature') | float(0) }}
+    turn_on_below: "{{ target_plus_offset - margin }}"
+    turn_off_above: "{{ target_plus_offset + margin }}"
     desired_state: >-
       {{ "on" if temp < turn_on_below else
          "off" if temp > turn_off_above else
@@ -28,18 +40,23 @@
               entity_id: switch.plug_floor_heating_pump
   mode: restart
 
-# Run pump for 30 mins daily when power's cheap, intended to keep the water flowing regularly
-# outside of the heating season.
-# This can probably by improved by checking first whether the pump ran at all today.
+# Run pump for 30 mins daily at night outside of the heating season,
+# intended to keep the water flowing regularly.
 - alias: "Floor Heating Pump Nightly Flush"
   id: floor-heating-pump-nightly-flush
   trigger:
     - platform: time
       at: '03:00:00'
   condition:
-    - condition: state
-      entity_id: switch.plug_floor_heating_pump
-      state: "off"
+    condition: and
+    conditions:
+      - condition: state
+        entity_id: switch.plug_floor_heating_pump
+        state: "off"
+      # Proxy for "not in heating season":
+      - condition: numeric_state
+        entity_id: sensor.climate_living_room_temperature
+        above: "{{ states('input_number.living_room_temperature_target') + 1 }}"
   action:
     - service: automation.turn_off
       entity_id: automation.floor_heating_pump_toggle
@@ -50,7 +67,7 @@
     - service: switch.turn_off
       target:
         entity_id: switch.plug_floor_heating_pump
-    - delay: '00:05:00'  # prevent super-quick power cycle (in case it's really cold)
+    - delay: '00:05:00'  # prevent super-quick power cycle
     - service: automation.turn_on
       entity_id: automation.floor_heating_pump_toggle
   mode: restart

--- a/home-assistant/config/automation/floor_heating_pump.yaml
+++ b/home-assistant/config/automation/floor_heating_pump.yaml
@@ -2,22 +2,25 @@
   id: floor-heating-pump-toggle
   trigger:
     - platform: template
+      alias: "Temp rose sufficiently to turn off"
       value_template: >-
-        {{ (states('sensor.climate_living_room_temperature') | float(0)) >
-           (states('input_number.living_room_temperature_target') +
-            states('input_number.living_room_temperature_pump_offset') +
-            states('input_number.living_room_temperature_pump_margin')
+        {{ states('sensor.climate_living_room_temperature') | float(100) >
+           (states('input_number.living_room_temperature_target') | float(0) +
+            states('input_number.living_room_temperature_pump_offset') | float(0) +
+            states('input_number.living_room_temperature_pump_margin') | float(0)
            )
         }}
     - platform: template
+      alias: "Temp dropped sufficiently to turn on"
       value_template: >-
-        {{ (states('sensor.climate_living_room_temperature') | float(0)) <
-           (states('input_number.living_room_temperature_target') +
-            states('input_number.living_room_temperature_pump_offset') -
-            states('input_number.living_room_temperature_pump_margin')
+        {{ states('sensor.climate_living_room_temperature') | float(0) <
+           (states('input_number.living_room_temperature_target') | float(0) +
+            states('input_number.living_room_temperature_pump_offset') | float(0) -
+            states('input_number.living_room_temperature_pump_margin') | float(0)
            )
         }}
-    # Fallback trigger, remove if we get enough comfort that numeric_state trigger does the job.
+    # Fallback trigger, consider removing if there is sufficient comfort that temp-based triggers
+    # do the job.
     # Used by to be every minute, but it led to a lot of spam in the Logbook.
     - platform: time_pattern
       hours: 1

--- a/home-assistant/config/automation/floor_heating_pump.yaml
+++ b/home-assistant/config/automation/floor_heating_pump.yaml
@@ -1,12 +1,27 @@
 - alias: "Floor Heating Pump toggle"
   id: floor-heating-pump-toggle
   trigger:
-    # TODO: Think of a better trigger that doesn't lead to log spam.
-    #       Want to use numeric_state on temperature, but fear it is
-    #       not reliable enough.
+    - platform: template
+      value_template: >-
+        {{ (states('sensor.climate_living_room_temperature') | float(0)) >
+           (states('input_number.living_room_temperature_target') +
+            states('input_number.living_room_temperature_pump_offset') +
+            states('input_number.living_room_temperature_pump_margin')
+           )
+        }}
+    - platform: template
+      value_template: >-
+        {{ (states('sensor.climate_living_room_temperature') | float(0)) <
+           (states('input_number.living_room_temperature_target') +
+            states('input_number.living_room_temperature_pump_offset') -
+            states('input_number.living_room_temperature_pump_margin')
+           )
+        }}
+    # Fallback trigger, remove if we get enough comfort that numeric_state trigger does the job.
+    # Used by to be every minute, but it led to a lot of spam in the Logbook.
     - platform: time_pattern
-      minutes: 5
-    - platform: home_assistant
+      hours: 1
+    - platform: homeassistant
       event: start
   variables:
     target_plus_offset: >-
@@ -56,7 +71,7 @@
       # Proxy for "not in heating season":
       - condition: numeric_state
         entity_id: sensor.climate_living_room_temperature
-        above: "{{ states('input_number.living_room_temperature_target') + 1 }}"
+        above: 22
   action:
     - service: automation.turn_off
       entity_id: automation.floor_heating_pump_toggle
@@ -67,7 +82,6 @@
     - service: switch.turn_off
       target:
         entity_id: switch.plug_floor_heating_pump
-    - delay: '00:05:00'  # prevent super-quick power cycle
     - service: automation.turn_on
       entity_id: automation.floor_heating_pump_toggle
   mode: restart

--- a/home-assistant/config/input_number.yaml
+++ b/home-assistant/config/input_number.yaml
@@ -1,3 +1,26 @@
+living_room_temperature_target:
+  name: Living Room Temperature Target (workaround due to lacking a smart thermostat)
+  initial: 19
+  min: 16
+  max: 22
+  step: 0.5
+  mode: box
+living_room_temperature_pump_offset:
+  name: Offset to add to target to ensure pump doesn't switch off too early.
+  initial: 0.5
+  min: 0.1
+  max: 2.0
+  step: 0.1
+  mode: box
+living_room_temperature_pump_margin:
+  name: Margin around (target + offset) where no action is performed.
+  # Accounts for sensor instability, prevents flip/flopping
+  initial: 0.1
+  min: 0.0
+  max: 1.0
+  step: 0.01
+  mode: box
+
 proximity_activated_light_living_brightness:
   initial: 50
   min: 1


### PR DESCRIPTION
When dropping from 19 to 18, it takes forever to heat up again:

![vloerverwarming-bg-nachtverlaging](https://github.com/jvanlier/infra-pi-home/assets/1831470/ba0d1239-85f4-41ce-afae-b55b194dd619)

When dropping from 19 to 18.5, temp doesn't rise to 19 anymore during the day:

<img width="1652" alt="image" src="https://github.com/jvanlier/infra-pi-home/assets/1831470/6d69e0d3-6820-4a96-83d5-36917bd9da6e">

 Have a feeling the thermostat isn't sensitive enough.
So, simplify things and stick to 19 around the clock.

Also, switch hardcoded constants to input numbers.