### PR TITLE
Add zigbee device offline sensor/alert

### DIFF
--- a/home-assistant-amb/config/automation/zigbee_device_offline.yaml
+++ b/home-assistant-amb/config/automation/zigbee_device_offline.yaml
@@ -4,10 +4,20 @@
   alias: Zigbee Device Offline Notification
   trigger:
     - platform: state
-      entity_id: sensor.zigbee_device_offline
+      entity_id: &templ_sensor sensor.zigbee_device_offline
+    - platform: time
+      at: "20:00:00"
+  variables:
+    templ_sensor: *templ_sensor
+  condition:
+    - condition: template
+      value_template: "{{ states(templ_sensor) != '' }}"
   action:
+    # Wait for a little while to allow multiple changes to accumulate.
+    # Due to mode restart, this instance will get killed if a new one starts.
+    - delay: "00:10:00"
     - service: notify.mobile_app_j16
       data:
-        title: "Zigbee Device Offline"
-        message: "{{ states('sensor.zigbee_device_offline') }}"
+        title: "Zigbee Device Offline status change"
+        message: "{{ states(templ_sensor) }}"
   mode: restart

--- a/home-assistant-amb/config/automation/zigbee_device_offline.yaml
+++ b/home-assistant-amb/config/automation/zigbee_device_offline.yaml
@@ -1,0 +1,13 @@
+# Relies on template sensor in sensor/zigbee_device_offline.yaml
+
+- id: zigbee_device_offline
+  alias: Zigbee Device Offline Notification
+  trigger:
+    - platform: state
+      entity_id: sensor.zigbee_device_offline
+  action:
+    - service: notify.mobile_app_j16
+      data:
+        title: "Zigbee Device Offline"
+        message: "{{ states('sensor.zigbee_device_offline') }}"
+  mode: restart

--- a/home-assistant-amb/config/automation/zigbee_device_offline.yaml
+++ b/home-assistant-amb/config/automation/zigbee_device_offline.yaml
@@ -15,7 +15,7 @@
   action:
     # Wait for a little while to allow multiple changes to accumulate.
     # Due to mode restart, this instance will get killed if a new one starts.
-    - delay: "00:10:00"
+    - delay: "00:00:10"
     - service: notify.mobile_app_j16
       data:
         title: "Zigbee Device Offline status change"

--- a/home-assistant-amb/config/sensor/zigbee_device_offline.yaml
+++ b/home-assistant-amb/config/sensor/zigbee_device_offline.yaml
@@ -34,5 +34,5 @@
              {% endif %}
            {% endif %}
          {% endfor %}
-         {{ result.sensors | sort | join('\n') }} | truncate(254, True) }}
+         {{ result.sensors | sort | join('\n') | truncate(254, True) }}
       # N.b.: truncating to 254 chars to to fit within max. length, otherwise value is "unknown"

--- a/home-assistant-amb/config/sensor/zigbee_device_offline.yaml
+++ b/home-assistant-amb/config/sensor/zigbee_device_offline.yaml
@@ -1,0 +1,35 @@
+# Requires Z2M settings:
+#
+# availability:
+#   enabled: true
+# advanced:
+#   last_seen: "ISO_8601"
+# device_options:
+#   homeassistant:
+#     last_seen:
+#       enabled_by_default: true
+
+ - platform: template
+   sensors:
+     zigbee_device_offline:
+       friendly_name: Zigbee Device Offline
+       value_template: >-
+         {% set result = namespace(sensors=[]) %}
+         {% for state in states.sensor |
+             rejectattr('attributes.device_class', 'undefined') |
+             selectattr('attributes.device_class', '==', 'timestamp') 
+         %}
+           {% if 'last_seen' in state.entity_id %}
+             {% set pretty_name = state.name | replace(" Last seen", "") %}
+             {% if states(state.entity_id) in ("unknown", "unavailable") %}
+               {% set result.sensors = result.sensors + [pretty_name ~ ": " ~ states(state.entity_id)] %}
+             {% else %}
+               {% set last_seen_timestamp = as_timestamp(states(state.entity_id)) %}
+               {% if (as_timestamp(now()) - last_seen_timestamp) > (24 * 60 * 60) %}
+                 {% set time_ago = relative_time(strptime(states(state.entity_id), '%Y-%m-%dT%H:%M:%S%z')) %}
+                 {% set result.sensors = result.sensors + [pretty_name ~ ": " ~ last_seen_timestamp | timestamp_custom("%Y-%m-%d %H:%M:%S")] %}
+               {% endif %}
+             {% endif %}
+           {% endif %}
+         {% endfor %}
+         {{ result.sensors | sort | join('\n') }} {# | truncate(254, True) }} #}

--- a/home-assistant-amb/config/sensor/zigbee_device_offline.yaml
+++ b/home-assistant-amb/config/sensor/zigbee_device_offline.yaml
@@ -34,4 +34,5 @@
              {% endif %}
            {% endif %}
          {% endfor %}
-         {{ result.sensors | sort | join('\n') }} {# | truncate(254, True) }} #}
+         {{ result.sensors | sort | join('\n') }} | truncate(254, True) }}
+      # N.b.: truncating to 254 chars to to fit within max. length, otherwise value is "unknown"

--- a/home-assistant-amb/config/sensor/zigbee_device_offline.yaml
+++ b/home-assistant-amb/config/sensor/zigbee_device_offline.yaml
@@ -17,7 +17,7 @@
          {% set result = namespace(sensors=[]) %}
          {% for state in states.sensor |
              rejectattr('attributes.device_class', 'undefined') |
-             selectattr('attributes.device_class', '==', 'timestamp') 
+             selectattr('attributes.device_class', '==', 'timestamp')
          %}
            {% if 'last_seen' in state.entity_id %}
              {% set pretty_name = state.name | replace(" Last seen", "") %}

--- a/home-assistant-amb/config/sensor/zigbee_device_offline.yaml
+++ b/home-assistant-amb/config/sensor/zigbee_device_offline.yaml
@@ -8,6 +8,8 @@
 #   homeassistant:
 #     last_seen:
 #       enabled_by_default: true
+#
+# Inspired by: https://www.homeautomationguy.io/blog/managing-offline-devices-in-zigbee2mqtt
 
  - platform: template
    sensors:

--- a/zigbee2mqtt-amb/zigbee2mqtt-data/configuration.yaml
+++ b/zigbee2mqtt-amb/zigbee2mqtt-data/configuration.yaml
@@ -17,8 +17,12 @@ advanced:
   channel: 25
   pan_id: 35539
   network_key: '!secret.yaml network_key'
-  log_level: info
-device_options: {}
+  log_level: warning
+  last_seen: "ISO_8601"
+device_options:
+  homeassistant:
+    last_seen:
+      enabled_by_default: true
 version: 4
 devices:
   '0x0000000001732f4d':


### PR DESCRIPTION
This PR adds a template sensor that monitors z2m last seen statuses, and an alert when the status changes.

Mostly reused from https://www.homeautomationguy.io/blog/managing-offline-devices-in-zigbee2mqtt.

Example value of the template sensor in template editor (changing the threshold for demo purposes to make more entries show up): 

<img width="1670" height="460" alt="image" src="https://github.com/user-attachments/assets/147fd124-8915-4491-aa76-8861b6646811" />


Z2m:

<img width="1670" height="460" alt="image" src="https://github.com/user-attachments/assets/e8789fb0-1436-4d4f-b33e-6daab2e5f1af" />


(Water leak sensor 4 days ago was before I activated the "last seen" sharing, so HA is not aware).

Alert on iOS (with the actual threshold):

![IMG_44C7C7AFE633-1](https://github.com/user-attachments/assets/2bdf271b-d245-4d01-a94c-133f6b33cd1f)
