### PR TITLE
Fix Home Assistant configuration issues from code review

### DIFF
--- a/home-assistant-amb/config/adaptive_lighting.yaml
+++ b/home-assistant-amb/config/adaptive_lighting.yaml
@@ -1,5 +1,5 @@
 # N.b.: when adding/removing configs, also update:
-# - automation/light_adaptive.yaml
+# - automation/light_adaptive_toggle.yaml
 # - automation/sleep_mode.yaml
 
 - name: "hall-0-spot"

--- a/home-assistant-amb/config/automation/light_hall_0.yaml
+++ b/home-assistant-amb/config/automation/light_hall_0.yaml
@@ -8,7 +8,7 @@
       total_no_motion_wait: 300
       light_entity_id: light.light_hall_0_wall
       adaptive_light_entity: switch.adaptive_lighting_hall_0_wall
-      dim_script: script.turn_on_light_hall_0_spot_dimmed
+      dim_script: script.turn_on_light_hall_0_wall_dimmed
 
 - alias: Motion-activated Light Hall 0 Spot
   id: mal-hall-0-spot
@@ -20,7 +20,7 @@
       total_no_motion_wait: 300
       light_entity_id: light.light_group_hall_0_spot
       adaptive_light_entity: switch.adaptive_lighting_hall_0_spot
-      dim_script: script.turn_on_light_hall_0_wall_dimmed
+      dim_script: script.turn_on_light_hall_0_spot_dimmed
 
 - alias: Light hall 0 on to dimmed state
   id: light-hall-0-on-to-dimmed

--- a/home-assistant-amb/config/automation/power.yaml
+++ b/home-assistant-amb/config/automation/power.yaml
@@ -9,7 +9,7 @@
       above: 25
     # L3 is not connected
   action:
-    - service: notify.mobile_app_J16
+    - service: notify.mobile_app_j16
       data:
         title: Electricity overload warning
         message: >

--- a/home-assistant-amb/config/automation/switch_bedroom_jc.yaml
+++ b/home-assistant-amb/config/automation/switch_bedroom_jc.yaml
@@ -1,5 +1,5 @@
 - alias: Switch Dimmer Bedroom JC Bed C
-  id: switch-dimme-bedroom-jc-bed-c
+  id: switch-dimmer-bedroom-jc-bed-c
   description: ""
   use_blueprint:
     path: custom/hue_dimmer_switch.yaml
@@ -33,7 +33,7 @@
             entity_id: *ref_c
 
 - alias: Switch Dimmer Bedroom JC Bed J
-  id: switch-dimme-bedroom-jc-bed-j
+  id: switch-dimmer-bedroom-jc-bed-j
   description: ""
   use_blueprint:
     path: custom/hue_dimmer_switch.yaml

--- a/home-assistant-amb/config/automation/wake_up_light_kids.yaml
+++ b/home-assistant-amb/config/automation/wake_up_light_kids.yaml
@@ -12,7 +12,7 @@
     - service: input_boolean.turn_on
       target:
         entity_id: &bool_in_progress input_boolean.wake_up_lights_kids_cycle_in_progress
-    # With explictly marking manual control, AL overrides the color:
+    # Without explicitly marking manual control, AL overrides the color:
     - service: adaptive_lighting.set_manual_control
       entity_id:
         - switch.adaptive_lighting_bedroom_duco_color

--- a/home-assistant-amb/config/automation/washing_machine.yaml
+++ b/home-assistant-amb/config/automation/washing_machine.yaml
@@ -9,7 +9,7 @@
   action:
     - service: notify.notify
       data:
-        title: Washine machine
+        title: Washing machine
         message: Done
         data:
           push:

--- a/home-assistant-amb/config/binary_sensor.yaml
+++ b/home-assistant-amb/config/binary_sensor.yaml
@@ -1,0 +1,2 @@
+# Empty file - binary_sensor key required by configuration.yaml, but all template
+# binary sensors are defined in template/*.yaml using the newer template integration syntax.

--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_adaptive_lighting.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_adaptive_lighting.yaml
@@ -62,7 +62,7 @@ blueprint:
     left_switch_entities_adapt_brightness:
       name: Adaptive Lighting adapt brightness switch entities (all).
       description: >
-        The adaptive lighting switches, in order to  adaptive brightness when dimming them via the zigbee group (which is not in AL config).
+        The adaptive lighting switches, in order to disable adaptive brightness when dimming them via the zigbee group (which is not in AL config).
       selector:
         entity:
           domain: switch

--- a/home-assistant-amb/config/blueprints/automation/custom/light_disco.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/light_disco.yaml
@@ -1,7 +1,7 @@
 blueprint:
   name: Light Disco
   description: >
-    TODO
+    Cycle lights through random colors while input boolean is on.
 
   domain: automation
 

--- a/home-assistant-amb/config/blueprints/automation/custom/light_motion_activated_dark_aware_script.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/light_motion_activated_dark_aware_script.yaml
@@ -7,7 +7,7 @@ blueprint:
     Alternate version that takes the entity id of a script to go into dimmed state. Useful for DRY when you want
     to go immediately into dimmed state upon other triggers as well.
 
-    Supports only a single light entity, with associated adaptive ligthting config.
+    Supports only a single light entity, with associated adaptive lighting config.
     The adaptive lighting entity should not be shared with other lights, because adapt brightness gets turned off.
   domain: automation
   input:

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -31,8 +31,6 @@ views:
             heading: Living
             heading_style: subtitle
             icon: mdi:sofa
-            features:
-              - type: light-brightness
           - type: tile
             name: Spot Always
             entity: light.light_group_living_spot_always
@@ -172,18 +170,10 @@ views:
             heading: Light automation
             heading_style: subtitle
             icon: mdi:robot
-            # tap_action:
-            #   action: navigate
-            #   navigation_path: /dashboard-lights/automation
           - type: tile
             entity: input_boolean.adaptive_lighting
             tap_action:
               action: toggle
-          # Input boolean not in use yet:
-          # - type: tile
-          #   entity: input_boolean.motion_activated_lights
-          #   tap_action:
-          #     action: toggle
   - title: Wake up lights
     path: wake-up-lights
     icon: mdi:alarm-check

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -113,11 +113,6 @@ views:
             entity: input_boolean.sleep_mode_kids
             tap_action:
               action: toggle
-          # Input boolean not in use yet:
-          # - type: tile
-          #   entity: input_boolean.housekeeping_mode
-          #   tap_action:
-          #     action: toggle
 
           - type: heading
             heading: Lights
@@ -209,18 +204,10 @@ views:
             heading: Light automation
             heading_style: subtitle
             icon: mdi:robot
-            # tap_action:
-            #   action: navigate
-            #   navigation_path: /dashboard-lights/automation
           - type: tile
             entity: input_boolean.adaptive_lighting
             tap_action:
               action: toggle
-          # Input boolean not in use yet:
-          # - type: tile
-          #   entity: input_boolean.motion_activated_lights
-          #   tap_action:
-          #     action: toggle
 
           - type: heading
             heading: Illuminance

--- a/home-assistant-amb/config/input_boolean.yaml
+++ b/home-assistant-amb/config/input_boolean.yaml
@@ -31,14 +31,3 @@ wake_up_lights_kids_cycle_in_progress:
   name: Wake Up Lights Kids Cycle In Progress
   icon: mdi:alarm-note
   initial: false
-
-# Not yet installed, coming soon:
-# motion_activated_lights:
-#   name: Motion Activated Lights
-#   icon: mdi:motion-sensor
-
-# TODO:
-# housekeeping_mode:
-#   # Toggle Adaptive Lighting + all motion sensors and set lights to max white.
-#   name: Housekeeping Mode
-#   icon: mdi:broom

--- a/home-assistant-amb/config/script.yaml
+++ b/home-assistant-amb/config/script.yaml
@@ -1,4 +1,4 @@
-# TODO: apparently script blueprints are a thing, move tot that.
+# TODO: apparently script blueprints are a thing, move to that.
 
 turn_on_light_kitchen_middle_dimmed:
   alias: "Turn on light kitchen middle dimmed"

--- a/home-assistant-amb/config/template/presence.yaml
+++ b/home-assistant-amb/config/template/presence.yaml
@@ -1,4 +1,4 @@
- # Footgun: Typos in entity ids are silently ignored.
+# Footgun: Typos in entity ids are silently ignored.
  # So these are not caught at test time, nor do they result in error in the logs.
  # Maybe change this to input_booleans + automations to set/unset in combination with a timer.
 
@@ -81,11 +81,13 @@
     name: Presence First Floor
     icon: mdi:numeric-1-box
     delay_off: "00:15:00"
+    # Note: motion_stairs_0_occupancy is intentionally in both ground and first floor
+    # presence sensors, as the stairs connect both floors.
     state: >
       {{ expand([
           "binary_sensor.motion_stairs_0_occupancy",
           "binary_sensor.motion_stairs_1_occupancy",
-          ]) | selectattr("state","eq","on") | list | count > 0
+          ]) | selectattr("state", "eq", "on") | list | count > 0
       }}
 
   - unique_id: presence_second_floor

--- a/home-assistant-amb/config/template/zigbee_device_offline.yaml
+++ b/home-assistant-amb/config/template/zigbee_device_offline.yaml
@@ -27,7 +27,6 @@
           {% else %}
             {% set last_seen_timestamp = as_timestamp(states(state.entity_id)) %}
             {% if (as_timestamp(now()) - last_seen_timestamp) > (24 * 60 * 60) %}
-              {% set time_ago = relative_time(strptime(states(state.entity_id), '%Y-%m-%dT%H:%M:%S%z')) %}
               {% set result.sensors = result.sensors + [pretty_name ~ ": " ~ last_seen_timestamp | timestamp_custom("%Y-%m-%d %H:%M:%S")] %}
             {% endif %}
           {% endif %}


### PR DESCRIPTION
- Fix dim_script swap in hall 0 automations (wall should dim wall, spot should dim spot)
- Fix automation ID typos (switch-dimme -> switch-dimmer)
- Make YAML anchor names unique per file to prevent collisions
- Remove unused time_ago variable in zigbee offline sensor
- Remove invalid features block on heading card in dashboard
- Fix typos: Washine->Washing, ligthting->lighting, explictly->explicitly, tot->to
- Update stale comment reference (light_adaptive.yaml -> light_adaptive_toggle.yaml)
- Fill in light_disco blueprint description
- Fix missing verb in wall switch blueprint description
- Standardize notify target to lowercase (mobile_app_j16)
- Add explanatory comment to empty binary_sensor.yaml
- Add comment about intentional stairs sensor overlap in presence detection
- Standardize Jinja spacing in presence template
- Remove stale commented-out code from dashboards and input_boolean