### PR TITLE
Increase kitchen light sleep brightness

### DIFF
--- a/home-assistant-amb/config/adaptive_lighting.yaml
+++ b/home-assistant-amb/config/adaptive_lighting.yaml
@@ -75,7 +75,7 @@
   max_brightness: 40
   min_color_temp: 2700
   max_color_temp: 4000
-  sleep_brightness: 4
+  sleep_brightness: 8
   sleep_transition: 5
 
 - name: "kitchen-countertop"
@@ -84,7 +84,7 @@
   max_brightness: 80
   min_color_temp: 2700
   max_color_temp: 4000
-  sleep_brightness: 8
+  sleep_brightness: 16
   sleep_transition: 5
 
 - name: "bathroom"


### PR DESCRIPTION
## Summary
- Increase kitchen-middle sleep brightness from 4 to 8
- Increase kitchen-countertop sleep brightness from 8 to 16

## Test plan
- [ ] Check out branch on Raspberry Pi and reload HA configuration
- [ ] Activate sleep mode and verify kitchen lights are brighter than before