### PR TITLE
Add Bedroom Duco New wall switch and dashboards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,8 @@ When modifying Home Assistant configuration:
 
 1. Edit YAML files in `home-assistant-amb/config/`
 2. Run `just test` to validate configuration locally. If there are no problems, there is no output. It may seem like it didn't work. Make sure the return code is not an error code.
-3. Create a branch, commit and push (CI will validate again)
+3. Always run `just test` immediately before committing. Do not commit or push if it fails.
+4. Create a branch, commit and push (CI will validate again)
 4. To verify on live Home Assistant
     - If the image is unchanged, instruct the user to checkout the branch on Raspberry pi (or simply pull if that has already happened and we're iterating), and reload configuration or restart via UI
     - If the image is changed (either the `Dockerfile` itself or the tag in `docker-compose.yaml`), instruct the user to run `docker compose up -d --build` on the Raspberry pi in the `home-assistant-amb` directory.

--- a/home-assistant-amb/config/automation/switch_bedroom_duco_new.yaml
+++ b/home-assistant-amb/config/automation/switch_bedroom_duco_new.yaml
@@ -1,0 +1,10 @@
+- alias: Switch Wall Bedroom Duco New
+  id: switch_wall_bedroom_duco_new
+  use_blueprint:
+    path: custom/hue_wall_switch.yaml
+    input:
+      controller: switch_wall_bedroom_duco_new
+      left_press:
+        - action: light.toggle
+          target:
+            entity_id: light.light_group_bedroom_duco_new

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -142,6 +142,16 @@ views:
             entity: input_boolean.disco_duco
 
           - type: heading
+            heading: Bedroom Duco New
+            heading_style: subtitle
+            icon: mdi:bed
+          - type: tile
+            name: Bedroom Duco New
+            entity: light.light_group_bedroom_duco_new
+            features:
+              - type: light-brightness
+
+          - type: heading
             heading: Bedroom JC
             heading_style: subtitle
             icon: mdi:bed

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -181,6 +181,9 @@ views:
             name: Duco Color
             entity: light.light_group_bedroom_duco_color
           - type: tile
+            name: Duco New
+            entity: light.light_group_bedroom_duco_new
+          - type: tile
             name: Olivier Ambiance
             entity: light.light_group_bedroom_olivier_ambiance
           - type: tile


### PR DESCRIPTION
## Summary
- Add wall switch automation for Bedroom Duco New using the simple `hue_wall_switch` blueprint (left press toggles `light.light_group_bedroom_duco_new`)
- Add Bedroom Duco New section to the lights dashboard with brightness slider
- Add Duco New tile to the bedrooms section of the overview dashboard

No adaptive lighting, tap dial, or disco mode — room is pending redecoration.