### PR TITLE
Add Hue Wall Switch hold-to-dim blueprint

### DIFF
--- a/home-assistant-amb/config/automation/switch_bedroom_duco_new.yaml
+++ b/home-assistant-amb/config/automation/switch_bedroom_duco_new.yaml
@@ -1,10 +1,9 @@
 - alias: Switch Wall Bedroom Duco New
   id: switch_wall_bedroom_duco_new
   use_blueprint:
-    path: custom/hue_wall_switch.yaml
+    path: custom/hue_wall_switch_dim.yaml
     input:
       controller: Switch Wall Bedroom Duco New
-      left_press:
-        - action: light.toggle
-          target:
-            entity_id: light.light_group_bedroom_duco_new
+      left_light:
+        - light.light_group_bedroom_duco_new
+      left_dim_direction_entity: input_text.dim_direction_switch_wall_bedroom_duco_new_left

--- a/home-assistant-amb/config/automation/switch_kitchen.yaml
+++ b/home-assistant-amb/config/automation/switch_kitchen.yaml
@@ -1,12 +1,10 @@
 - alias: Switch Wall Kitchen
   id: switch_wall_kitchen
   use_blueprint:
-    path: custom/hue_wall_switch.yaml
+    path: custom/hue_wall_switch_dim.yaml
     input:
       controller: Switch Wall Kitchen
-      left_press:
-        - action: light.toggle
-          target:
-            entity_id:
-              - light.light_group_kitchen_middle
-              - light.light_group_kitchen_countertop
+      left_light:
+        - light.light_group_kitchen_middle
+        - light.light_group_kitchen_countertop
+      left_dim_direction_entity: input_text.dim_direction_switch_wall_kitchen_left

--- a/home-assistant-amb/config/automation/switch_living.yaml
+++ b/home-assistant-amb/config/automation/switch_living.yaml
@@ -2,29 +2,19 @@
 - alias: Switch Wall Living
   id: switch_wall_living
   use_blueprint:
-    path: custom/hue_wall_switch.yaml
+    path: custom/hue_wall_switch_dim.yaml
     input:
       controller: Switch Wall Living
-      left_press:
-        - action: light.toggle
-          target:
-            entity_id: light.light_dining_table
-      right_press:
-          - choose:
-              - conditions:
-                  - condition: state
-                    entity_id: binary_sensor.sufficiently_dark_for_indoor_lights
-                    state: "on"
-                sequence:
-                  - service: light.toggle
-                    target:
-                      entity_id:
-                        - light.light_group_living_spot_dark_outside
-                        - light.light_group_living_spot_always
-            default:
-              - service: light.toggle
-                target:
-                  entity_id: light.light_group_living_spot_always
+      left_light:
+        - light.light_dining_table
+      left_dim_direction_entity: input_text.dim_direction_switch_wall_living_left
+      right_light:
+        - light.light_group_living_spot_always
+        - light.light_group_living_spot_dark_outside
+      right_dim_direction_entity: input_text.dim_direction_switch_wall_living_right
+      right_condition_entity: binary_sensor.sufficiently_dark_for_indoor_lights
+      right_light_alt:
+        - light.light_group_living_spot_always
 
 - alias: Switch Tap Dial Living
   id: switch_tap_dial_living

--- a/home-assistant-amb/config/automation/switch_toilet.yaml
+++ b/home-assistant-amb/config/automation/switch_toilet.yaml
@@ -6,4 +6,4 @@
     input:
       controller: Switch Wall Toilet
       left_light: light.light_toilet
-      dim_direction_entity: input_text.dim_direction_switch_wall_toilet
+      left_dim_direction_entity: input_text.dim_direction_switch_wall_toilet_left

--- a/home-assistant-amb/config/automation/switch_toilet.yaml
+++ b/home-assistant-amb/config/automation/switch_toilet.yaml
@@ -5,5 +5,6 @@
     path: custom/hue_wall_switch_dim.yaml
     input:
       controller: Switch Wall Toilet
-      left_light: light.light_toilet
+      left_light:
+        - light.light_toilet
       left_dim_direction_entity: input_text.dim_direction_switch_wall_toilet_left

--- a/home-assistant-amb/config/automation/switch_toilet.yaml
+++ b/home-assistant-amb/config/automation/switch_toilet.yaml
@@ -2,10 +2,8 @@
 - alias: Switch Wall Toilet
   id: switch_wall_toilet
   use_blueprint:
-    path: custom/hue_wall_switch.yaml
+    path: custom/hue_wall_switch_dim.yaml
     input:
       controller: Switch Wall Toilet
-      left_press:
-        - action: light.toggle
-          target:
-            entity_id: light.light_toilet
+      left_light: light.light_toilet
+      dim_direction_entity: input_text.dim_direction_switch_wall_toilet

--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
@@ -25,7 +25,7 @@ blueprint:
     brightness_step_pct:
       name: Brightness step percentage
       description: Percentage to change brightness per hold event.
-      default: 10
+      default: 15
       selector:
         number:
           min: 3

--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
@@ -137,7 +137,7 @@ action:
           - action: light.turn_on
             data:
               brightness_pct: "{{ target_brightness }}"
-              transition: 1
+              transition: 0.8
             target:
               entity_id: "{{ light_entity }}"
           - action: input_text.set_value

--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
@@ -7,7 +7,7 @@ blueprint:
     Hold: dim light brightness. First hold dims down, next hold (within 5s) dims up, alternating.
 
     Requires push button mode configured in Zigbee2MQTT.
-    Requires an input_text helper for dim direction state tracking (initial value: "left_down_0|right_down_0").
+    Requires one input_text helper per button side for dim direction state (initial value: "down_0").
   domain: automation
 
   input:
@@ -47,6 +47,16 @@ blueprint:
         entity:
           domain: light
           multiple: false
+    left_dim_direction_entity:
+      name: Left dim direction input_text helper
+      description: >
+        An input_text entity for persisting left button dim direction state.
+        Initial value: "down_0".
+      selector:
+        entity:
+          domain: input_text
+          multiple: false
+
     right_light:
       name: Right button light (optional)
       description: Light entity to control with the right button. Leave empty to disable.
@@ -55,12 +65,12 @@ blueprint:
         entity:
           domain: light
           multiple: false
-
-    dim_direction_entity:
-      name: Dim direction input_text helper
+    right_dim_direction_entity:
+      name: Right dim direction input_text helper (optional)
       description: >
-        An input_text entity for persisting dim direction state.
-        Create one per switch. Initial value: "left_down_0|right_down_0".
+        An input_text entity for persisting right button dim direction state.
+        Initial value: "down_0". Required when right_light is set.
+      default: []
       selector:
         entity:
           domain: input_text
@@ -93,7 +103,9 @@ action:
       light_left: !input left_light
       light_right: !input right_light
       light_entity: "{{ light_left if side == 'left' else light_right }}"
-      dim_direction_entity: !input dim_direction_entity
+      dim_dir_left: !input left_dim_direction_entity
+      dim_dir_right: !input right_dim_direction_entity
+      dim_direction_entity: "{{ dim_dir_left if side == 'left' else dim_dir_right }}"
       brightness_step_pct: !input brightness_step_pct
       direction_timeout: !input direction_timeout
 
@@ -113,21 +125,9 @@ action:
             value_template: "{{ states(light_entity) == 'on' }}"
           - variables:
               raw_state: "{{ states(dim_direction_entity) }}"
-              parsed: >
-                {% set parts = raw_state.split('|') %}
-                {% set ns = namespace(dir='down', ts=0) %}
-                {% for part in parts %}
-                  {% if part.startswith(side ~ '_') %}
-                    {% set tokens = part.split('_') %}
-                    {% if tokens | length >= 3 %}
-                      {% set ns.dir = tokens[1] %}
-                      {% set ns.ts = tokens[2] | int(0) %}
-                    {% endif %}
-                  {% endif %}
-                {% endfor %}
-                {{ ns.dir ~ '|' ~ ns.ts }}
-              prev_dir: "{{ (parsed | trim).split('|')[0] }}"
-              prev_ts: "{{ (parsed | trim).split('|')[1] | int(0) }}"
+              parts: "{{ raw_state.split('_') }}"
+              prev_dir: "{{ parts[0] if parts | length >= 2 else 'down' }}"
+              prev_ts: "{{ parts[1] | int(0) if parts | length >= 2 else 0 }}"
               now_ts: "{{ now().timestamp() | int }}"
               timed_out: "{{ (now_ts - prev_ts) > direction_timeout }}"
               current_dir: "{{ 'down' if timed_out else prev_dir }}"
@@ -142,42 +142,15 @@ action:
         sequence:
           - variables:
               raw_state: "{{ states(dim_direction_entity) }}"
-              parsed: >
-                {% set parts = raw_state.split('|') %}
-                {% set ns = namespace(dir='down', ts=0) %}
-                {% for part in parts %}
-                  {% if part.startswith(side ~ '_') %}
-                    {% set tokens = part.split('_') %}
-                    {% if tokens | length >= 3 %}
-                      {% set ns.dir = tokens[1] %}
-                      {% set ns.ts = tokens[2] | int(0) %}
-                    {% endif %}
-                  {% endif %}
-                {% endfor %}
-                {{ ns.dir ~ '|' ~ ns.ts }}
-              prev_dir: "{{ (parsed | trim).split('|')[0] }}"
-              prev_ts: "{{ (parsed | trim).split('|')[1] | int(0) }}"
+              parts: "{{ raw_state.split('_') }}"
+              prev_dir: "{{ parts[0] if parts | length >= 2 else 'down' }}"
+              prev_ts: "{{ parts[1] | int(0) if parts | length >= 2 else 0 }}"
               now_ts: "{{ now().timestamp() | int }}"
               timed_out: "{{ (now_ts - prev_ts) > direction_timeout }}"
               current_dir: "{{ 'down' if timed_out else prev_dir }}"
               next_dir: "{{ 'up' if current_dir == 'down' else 'down' }}"
-              new_state: >
-                {% set parts = raw_state.split('|') %}
-                {% set ns = namespace(found=false, result=[]) %}
-                {% for part in parts %}
-                  {% if part.startswith(side ~ '_') %}
-                    {% set ns.found = true %}
-                    {% set ns.result = ns.result + [side ~ '_' ~ next_dir ~ '_' ~ now_ts] %}
-                  {% else %}
-                    {% set ns.result = ns.result + [part] %}
-                  {% endif %}
-                {% endfor %}
-                {% if not ns.found %}
-                  {% set ns.result = ns.result + [side ~ '_' ~ next_dir ~ '_' ~ now_ts] %}
-                {% endif %}
-                {{ ns.result | join('|') | trim }}
           - action: input_text.set_value
             target:
               entity_id: "{{ dim_direction_entity }}"
             data:
-              value: "{{ new_state }}"
+              value: "{{ next_dir ~ '_' ~ now_ts }}"

--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
@@ -91,7 +91,7 @@ condition:
   - condition: template
     value_template: >
       {{ trigger.payload in [
-        'left_release', 'right_release',
+        'left_press_release', 'right_press_release',
         'left_hold', 'right_hold',
         'left_hold_release', 'right_hold_release'
       ] }}
@@ -113,7 +113,7 @@ action:
     value_template: "{{ not (side == 'right' and light_right == []) }}"
 
   - choose:
-      - conditions: "{{ command in ['left_release', 'right_release'] }}"
+      - conditions: "{{ command in ['left_press_release', 'right_press_release'] }}"
         sequence:
           - action: light.toggle
             target:

--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
@@ -140,6 +140,11 @@ action:
               transition: 1
             target:
               entity_id: "{{ light_entity }}"
+          - action: input_text.set_value
+            target:
+              entity_id: "{{ dim_direction_entity }}"
+            data:
+              value: "{{ current_dir ~ '_' ~ now_ts }}"
 
       - conditions: "{{ command in ['left_hold_release', 'right_hold_release'] }}"
         sequence:

--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
@@ -6,6 +6,9 @@ blueprint:
     Short press (release): toggle light on/off.
     Hold: dim light brightness. First hold dims down, next hold (within 5s) dims up, alternating.
 
+    Supports multiple light entities per button and optional conditional light selection
+    (e.g. different lights based on a binary sensor like darkness).
+
     Requires push button mode configured in Zigbee2MQTT.
     Requires one input_text helper per button side for dim direction state (initial value: "down_0").
   domain: automation
@@ -41,12 +44,12 @@ blueprint:
           unit_of_measurement: seconds
 
     left_light:
-      name: Left button light
-      description: Light entity to control with the left button.
+      name: Left button light(s)
+      description: Light entity or entities to control with the left button.
       selector:
         entity:
           domain: light
-          multiple: false
+          multiple: true
     left_dim_direction_entity:
       name: Left dim direction input_text helper
       description: >
@@ -56,15 +59,32 @@ blueprint:
         entity:
           domain: input_text
           multiple: false
-
-    right_light:
-      name: Right button light (optional)
-      description: Light entity to control with the right button. Leave empty to disable.
+    left_condition_entity:
+      name: Left condition entity (optional)
+      description: >
+        Binary sensor. When "on", left_light is used. When "off", left_light_alt is used.
+      default: []
+      selector:
+        entity:
+          domain: binary_sensor
+          multiple: false
+    left_light_alt:
+      name: Left button alternative light(s) (optional)
+      description: Alternative light entities when left_condition_entity is "off".
       default: []
       selector:
         entity:
           domain: light
-          multiple: false
+          multiple: true
+
+    right_light:
+      name: Right button light(s) (optional)
+      description: Light entity or entities to control with the right button. Leave empty to disable.
+      default: []
+      selector:
+        entity:
+          domain: light
+          multiple: true
     right_dim_direction_entity:
       name: Right dim direction input_text helper (optional)
       description: >
@@ -75,6 +95,23 @@ blueprint:
         entity:
           domain: input_text
           multiple: false
+    right_condition_entity:
+      name: Right condition entity (optional)
+      description: >
+        Binary sensor. When "on", right_light is used. When "off", right_light_alt is used.
+      default: []
+      selector:
+        entity:
+          domain: binary_sensor
+          multiple: false
+    right_light_alt:
+      name: Right button alternative light(s) (optional)
+      description: Alternative light entities when right_condition_entity is "off".
+      default: []
+      selector:
+        entity:
+          domain: light
+          multiple: true
 
 mode: parallel
 max: 10
@@ -102,7 +139,20 @@ action:
       side: "{{ 'left' if 'left' in command else 'right' }}"
       light_left: !input left_light
       light_right: !input right_light
-      light_entity: "{{ light_left if side == 'left' else light_right }}"
+      light_left_alt: !input left_light_alt
+      light_right_alt: !input right_light_alt
+      left_condition_entity: !input left_condition_entity
+      right_condition_entity: !input right_condition_entity
+      condition_entity: "{{ left_condition_entity if side == 'left' else right_condition_entity }}"
+      primary_lights: "{{ light_left if side == 'left' else light_right }}"
+      alt_lights: "{{ light_left_alt if side == 'left' else light_right_alt }}"
+      active_lights: >
+        {% if condition_entity != [] and not is_state(condition_entity, 'on') and alt_lights != [] %}
+          {{ alt_lights }}
+        {% else %}
+          {{ primary_lights }}
+        {% endif %}
+      first_light: "{{ active_lights[0] if active_lights | length > 0 else '' }}"
       dim_dir_left: !input left_dim_direction_entity
       dim_dir_right: !input right_dim_direction_entity
       dim_direction_entity: "{{ dim_dir_left if side == 'left' else dim_dir_right }}"
@@ -110,19 +160,19 @@ action:
       direction_timeout: !input direction_timeout
 
   - condition: template
-    value_template: "{{ not (side == 'right' and light_right == []) }}"
+    value_template: "{{ active_lights | length > 0 }}"
 
   - choose:
       - conditions: "{{ command in ['left_press_release', 'right_press_release'] }}"
         sequence:
           - action: light.toggle
             target:
-              entity_id: "{{ light_entity }}"
+              entity_id: "{{ active_lights }}"
 
       - conditions: "{{ command in ['left_hold', 'right_hold'] }}"
         sequence:
           - condition: template
-            value_template: "{{ states(light_entity) == 'on' }}"
+            value_template: "{{ states(first_light) == 'on' }}"
           - variables:
               raw_state: "{{ states(dim_direction_entity) }}"
               parts: "{{ raw_state.split('_') }}"
@@ -132,14 +182,18 @@ action:
               timed_out: "{{ (now_ts - prev_ts) > direction_timeout }}"
               current_dir: "{{ 'down' if timed_out else prev_dir }}"
               step_value: "{{ brightness_step_pct | int if current_dir == 'up' else (brightness_step_pct | int * -1) }}"
-              current_brightness: "{{ (state_attr(light_entity, 'brightness') | float(0) / 255 * 100) | round(0) | int }}"
-              target_brightness: "{{ [[current_brightness + step_value, 1] | max, 100] | min }}"
-          - action: light.turn_on
-            data:
-              brightness_pct: "{{ target_brightness }}"
-              transition: 0.8
-            target:
-              entity_id: "{{ light_entity }}"
+          - repeat:
+              for_each: "{{ active_lights }}"
+              sequence:
+                - variables:
+                    current_brightness: "{{ (state_attr(repeat.item, 'brightness') | float(0) / 255 * 100) | round(0) | int }}"
+                    target_brightness: "{{ [[current_brightness + step_value, 1] | max, 100] | min }}"
+                - action: light.turn_on
+                  data:
+                    brightness_pct: "{{ target_brightness }}"
+                    transition: 0.8
+                  target:
+                    entity_id: "{{ repeat.item }}"
           - action: input_text.set_value
             target:
               entity_id: "{{ dim_direction_entity }}"

--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
@@ -1,0 +1,183 @@
+blueprint:
+  name: Hue Wall Switch (Z2M) - Hold to Dim
+  description: >
+    Hue Wall Switch for Zigbee2MQTT with hold-to-dim support.
+
+    Short press (release): toggle light on/off.
+    Hold: dim light brightness. First hold dims down, next hold (within 5s) dims up, alternating.
+
+    Requires push button mode configured in Zigbee2MQTT.
+    Requires an input_text helper for dim direction state tracking (initial value: "left_down_0|right_down_0").
+  domain: automation
+
+  input:
+    controller:
+      name: (Zigbee2MQTT) Controller Name
+      description: The name of the device in Zigbee2MQTT
+      default: ""
+    base_topic:
+      name: Root/Base mqtt topic from Zigbee2MQTT
+      description: The Root/base topic as configured in Zigbee2MQTT
+      default: zigbee2mqtt
+    brightness_step_pct:
+      name: Brightness step percentage
+      description: Percentage to change brightness per hold event.
+      default: 10
+      selector:
+        number:
+          min: 3
+          max: 25
+          step: 1
+          unit_of_measurement: "%"
+    direction_timeout:
+      name: Direction timeout
+      description: Seconds after the last dim before direction resets to "down".
+      default: 5
+      selector:
+        number:
+          min: 2
+          max: 30
+          step: 1
+          unit_of_measurement: seconds
+
+    left_light:
+      name: Left button light
+      description: Light entity to control with the left button.
+      selector:
+        entity:
+          domain: light
+          multiple: false
+    right_light:
+      name: Right button light (optional)
+      description: Light entity to control with the right button. Leave empty to disable.
+      default: []
+      selector:
+        entity:
+          domain: light
+          multiple: false
+
+    dim_direction_entity:
+      name: Dim direction input_text helper
+      description: >
+        An input_text entity for persisting dim direction state.
+        Create one per switch. Initial value: "left_down_0|right_down_0".
+      selector:
+        entity:
+          domain: input_text
+          multiple: false
+
+mode: parallel
+max: 10
+
+trigger_variables:
+  base_topic: !input base_topic
+  controller: !input controller
+
+trigger:
+  - platform: mqtt
+    topic: "{{ base_topic ~ '/' ~ controller ~ '/action' }}"
+
+condition:
+  - condition: template
+    value_template: >
+      {{ trigger.payload in [
+        'left_release', 'right_release',
+        'left_hold', 'right_hold',
+        'left_hold_release', 'right_hold_release'
+      ] }}
+
+action:
+  - variables:
+      command: "{{ trigger.payload }}"
+      side: "{{ 'left' if 'left' in command else 'right' }}"
+      light_left: !input left_light
+      light_right: !input right_light
+      light_entity: "{{ light_left if side == 'left' else light_right }}"
+      dim_direction_entity: !input dim_direction_entity
+      brightness_step_pct: !input brightness_step_pct
+      direction_timeout: !input direction_timeout
+
+  - condition: template
+    value_template: "{{ not (side == 'right' and light_right == []) }}"
+
+  - choose:
+      - conditions: "{{ command in ['left_release', 'right_release'] }}"
+        sequence:
+          - action: light.toggle
+            target:
+              entity_id: "{{ light_entity }}"
+
+      - conditions: "{{ command in ['left_hold', 'right_hold'] }}"
+        sequence:
+          - condition: template
+            value_template: "{{ states(light_entity) == 'on' }}"
+          - variables:
+              raw_state: "{{ states(dim_direction_entity) }}"
+              parsed: >
+                {% set parts = raw_state.split('|') %}
+                {% set ns = namespace(dir='down', ts=0) %}
+                {% for part in parts %}
+                  {% if part.startswith(side ~ '_') %}
+                    {% set tokens = part.split('_') %}
+                    {% if tokens | length >= 3 %}
+                      {% set ns.dir = tokens[1] %}
+                      {% set ns.ts = tokens[2] | int(0) %}
+                    {% endif %}
+                  {% endif %}
+                {% endfor %}
+                {{ ns.dir ~ '|' ~ ns.ts }}
+              prev_dir: "{{ (parsed | trim).split('|')[0] }}"
+              prev_ts: "{{ (parsed | trim).split('|')[1] | int(0) }}"
+              now_ts: "{{ now().timestamp() | int }}"
+              timed_out: "{{ (now_ts - prev_ts) > direction_timeout }}"
+              current_dir: "{{ 'down' if timed_out else prev_dir }}"
+              step_value: "{{ brightness_step_pct | int if current_dir == 'up' else (brightness_step_pct | int * -1) }}"
+          - action: light.turn_on
+            data:
+              brightness_step_pct: "{{ step_value }}"
+            target:
+              entity_id: "{{ light_entity }}"
+
+      - conditions: "{{ command in ['left_hold_release', 'right_hold_release'] }}"
+        sequence:
+          - variables:
+              raw_state: "{{ states(dim_direction_entity) }}"
+              parsed: >
+                {% set parts = raw_state.split('|') %}
+                {% set ns = namespace(dir='down', ts=0) %}
+                {% for part in parts %}
+                  {% if part.startswith(side ~ '_') %}
+                    {% set tokens = part.split('_') %}
+                    {% if tokens | length >= 3 %}
+                      {% set ns.dir = tokens[1] %}
+                      {% set ns.ts = tokens[2] | int(0) %}
+                    {% endif %}
+                  {% endif %}
+                {% endfor %}
+                {{ ns.dir ~ '|' ~ ns.ts }}
+              prev_dir: "{{ (parsed | trim).split('|')[0] }}"
+              prev_ts: "{{ (parsed | trim).split('|')[1] | int(0) }}"
+              now_ts: "{{ now().timestamp() | int }}"
+              timed_out: "{{ (now_ts - prev_ts) > direction_timeout }}"
+              current_dir: "{{ 'down' if timed_out else prev_dir }}"
+              next_dir: "{{ 'up' if current_dir == 'down' else 'down' }}"
+              new_state: >
+                {% set parts = raw_state.split('|') %}
+                {% set ns = namespace(found=false, result=[]) %}
+                {% for part in parts %}
+                  {% if part.startswith(side ~ '_') %}
+                    {% set ns.found = true %}
+                    {% set ns.result = ns.result + [side ~ '_' ~ next_dir ~ '_' ~ now_ts] %}
+                  {% else %}
+                    {% set ns.result = ns.result + [part] %}
+                  {% endif %}
+                {% endfor %}
+                {% if not ns.found %}
+                  {% set ns.result = ns.result + [side ~ '_' ~ next_dir ~ '_' ~ now_ts] %}
+                {% endif %}
+                {{ ns.result | join('|') | trim }}
+          - action: input_text.set_value
+            target:
+              entity_id: "{{ dim_direction_entity }}"
+            data:
+              value: "{{ new_state }}"

--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
@@ -132,9 +132,12 @@ action:
               timed_out: "{{ (now_ts - prev_ts) > direction_timeout }}"
               current_dir: "{{ 'down' if timed_out else prev_dir }}"
               step_value: "{{ brightness_step_pct | int if current_dir == 'up' else (brightness_step_pct | int * -1) }}"
+              current_brightness: "{{ (state_attr(light_entity, 'brightness') | float(0) / 255 * 100) | round(0) | int }}"
+              target_brightness: "{{ [[current_brightness + step_value, 1] | max, 100] | min }}"
           - action: light.turn_on
             data:
-              brightness_step_pct: "{{ step_value }}"
+              brightness_pct: "{{ target_brightness }}"
+              transition: 1
             target:
               entity_id: "{{ light_entity }}"
 

--- a/home-assistant-amb/config/configuration.yaml
+++ b/home-assistant-amb/config/configuration.yaml
@@ -22,6 +22,7 @@ template: !include_dir_merge_list template/
 input_boolean: !include input_boolean.yaml
 input_datetime: !include input_datetime.yaml
 input_number: !include input_number.yaml
+input_text: !include input_text.yaml
 lovelace: !include lovelace.yaml
 logbook: !include logbook.yaml
 script: !include script.yaml

--- a/home-assistant-amb/config/input_text.yaml
+++ b/home-assistant-amb/config/input_text.yaml
@@ -1,0 +1,4 @@
+dim_direction_switch_wall_toilet:
+  name: Dim direction Switch Wall Toilet
+  initial: "left_down_0|right_down_0"
+  max: 255

--- a/home-assistant-amb/config/input_text.yaml
+++ b/home-assistant-amb/config/input_text.yaml
@@ -17,3 +17,8 @@ dim_direction_switch_wall_living_right:
   name: Dim direction Switch Wall Living Right
   initial: "down_0"
   max: 30
+
+dim_direction_switch_wall_bedroom_duco_new_left:
+  name: Dim direction Switch Wall Bedroom Duco New Left
+  initial: "down_0"
+  max: 30

--- a/home-assistant-amb/config/input_text.yaml
+++ b/home-assistant-amb/config/input_text.yaml
@@ -1,4 +1,19 @@
 dim_direction_switch_wall_toilet_left:
   name: Dim direction Switch Wall Toilet Left
   initial: "down_0"
-  max: 255
+  max: 30
+
+dim_direction_switch_wall_kitchen_left:
+  name: Dim direction Switch Wall Kitchen Left
+  initial: "down_0"
+  max: 30
+
+dim_direction_switch_wall_living_left:
+  name: Dim direction Switch Wall Living Left
+  initial: "down_0"
+  max: 30
+
+dim_direction_switch_wall_living_right:
+  name: Dim direction Switch Wall Living Right
+  initial: "down_0"
+  max: 30

--- a/home-assistant-amb/config/input_text.yaml
+++ b/home-assistant-amb/config/input_text.yaml
@@ -1,4 +1,4 @@
-dim_direction_switch_wall_toilet:
-  name: Dim direction Switch Wall Toilet
-  initial: "left_down_0|right_down_0"
+dim_direction_switch_wall_toilet_left:
+  name: Dim direction Switch Wall Toilet Left
+  initial: "down_0"
   max: 255


### PR DESCRIPTION
## Summary
- New blueprint `hue_wall_switch_dim.yaml` that adds hold-to-dim support to Hue Wall Switches
- Short press (release event): toggles light on/off
- Hold: dims brightness step by step using the switch's native repeated `left_hold`/`right_hold` events (~810ms interval), with 0.8s transition for smooth dimming
- Direction alternates (down/up) on consecutive holds within 5 seconds, resets to down after timeout
- Brightness clamped to [1%, 100%] so dimming down never turns the light off
- Supports multiple light entities per button and optional conditional light selection via a binary sensor
- Direction state persisted in per-side `input_text` helpers
- Migrated wall switches: toilet, kitchen (2 groups), living room (left + conditional right), bedroom duco new

## Test plan
- [x] Toilet: short-press toggles, hold dims, direction alternates
- [x] Kitchen: left toggles/dims both kitchen_middle and kitchen_countertop
- [x] Living left: toggles/dims dining table
- [x] Living right (dark): toggles/dims both spot groups
- [x] Living right (not dark): toggles/dims spot_always only
- [x] Bedroom Duco New: left toggles/dims bedroom_duco_new group
- [x] Hold on turned-off light does nothing
- [x] Dimming down stops at 1% (light stays on)
- [x] Direction resets to down after 5s timeout