### PR TITLE
Update Home Assistant from 2026.3.2 to 2026.4.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ just build              # Build Docker image with custom components
 just test               # Validate Home Assistant configuration (requires Docker)
 ```
 
-The build process creates a custom Docker image based on `ghcr.io/home-assistant/home-assistant:2026.2.2` with two baked-in custom components:
+The build process creates a custom Docker image based on `ghcr.io/home-assistant/home-assistant:2026.4.3` with two baked-in custom components:
 - **adaptive-lighting**: Dynamic light color/brightness adjustment
 - **ha-illuminance**: Light level calculations based on weather/sun position
 

--- a/home-assistant-amb/docker/Dockerfile
+++ b/home-assistant-amb/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/home-assistant/home-assistant:2026.3.2
+FROM ghcr.io/home-assistant/home-assistant:2026.4.3
 
 ARG ADAPTIVE_LIGHTING_VERSION=1.30.1
 ARG HA_ILLUMINANCE_VERSION=5.7.0


### PR DESCRIPTION
## Summary
- Bumps Home Assistant base image from 2026.3.2 to 2026.4.3
- Updates version reference in CLAUDE.md