### PR TITLE
Preserve manual brightness when motion re-triggers automation

### DIFF
--- a/home-assistant-amb/config/blueprints/automation/custom/light_motion_activated_dark_aware.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/light_motion_activated_dark_aware.yaml
@@ -63,13 +63,20 @@ variables:
   device_no_motion_wait: !input device_no_motion_wait
   light_entity_id: !input light_entity_id
   dim_percentage: !input dim_percentage
+  adaptive_light_entity_id: !input adaptive_light_entity
 
 action:
-  - alias: "Apply adaptive lighting"
-    service: adaptive_lighting.apply
-    data:
-      entity_id: !input adaptive_light_entity
-      turn_on_lights: true
+  - alias: "Apply adaptive lighting if light is off or not manually controlled"
+    if:
+      - condition: template
+        value_template: >
+          {{ is_state(light_entity_id, 'off') or
+             light_entity_id not in state_attr(adaptive_light_entity_id, 'manual_control') | default([]) }}
+    then:
+      - service: adaptive_lighting.apply
+        data:
+          entity_id: !input adaptive_light_entity
+          turn_on_lights: true
   - alias: "Wait until there is no motion from device"
     wait_for_trigger:
       platform: state
@@ -99,6 +106,11 @@ action:
               transition: 5
             target:
               entity_id: !input light_entity_id
+          - alias: "Clear manual control so next motion re-applies adaptive lighting"
+            service: adaptive_lighting.set_manual_control
+            data:
+              entity_id: !input adaptive_light_entity
+              manual_control: false
     default:
       - alias: "Turn off the light"
         service: light.turn_off

--- a/home-assistant-amb/config/blueprints/automation/custom/light_motion_activated_dark_aware_script.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/light_motion_activated_dark_aware_script.yaml
@@ -62,13 +62,20 @@ variables:
   total_no_motion_wait: !input total_no_motion_wait
   device_no_motion_wait: !input device_no_motion_wait
   light_entity_id: !input light_entity_id
+  adaptive_light_entity_id: !input adaptive_light_entity
 
 action:
-  - alias: "Apply adaptive lighting"
-    service: adaptive_lighting.apply
-    data:
-      entity_id: !input adaptive_light_entity
-      turn_on_lights: true
+  - alias: "Apply adaptive lighting if light is off or not manually controlled"
+    if:
+      - condition: template
+        value_template: >
+          {{ is_state(light_entity_id, 'off') or
+             light_entity_id not in state_attr(adaptive_light_entity_id, 'manual_control') | default([]) }}
+    then:
+      - service: adaptive_lighting.apply
+        data:
+          entity_id: !input adaptive_light_entity
+          turn_on_lights: true
   - alias: "Wait until there is no motion from device"
     wait_for_trigger:
       platform: state
@@ -94,6 +101,11 @@ action:
           # Assumption: the script already disables adapt brightness
           - alias: "Dim the light"
             action: !input dim_script
+          - alias: "Clear manual control so next motion re-applies adaptive lighting"
+            service: adaptive_lighting.set_manual_control
+            data:
+              entity_id: !input adaptive_light_entity
+              manual_control: false
     default:
       - alias: "Turn off the light"
         service: light.turn_off


### PR DESCRIPTION
## Summary
- Skip `adaptive_lighting.apply` when the light is already on and under manual control, so user-adjusted brightness is not reset on motion re-trigger
- Clear `manual_control` after the dim script runs, so the next fresh motion event correctly restores adaptive brightness
- Applied to both blueprint variants (`light_motion_activated_dark_aware_script.yaml` and `light_motion_activated_dark_aware.yaml`)

## Test plan
- [ ] Reload automations in HA (Developer Tools > YAML > Reload Automations)
- [ ] Motion → light on → manually change brightness → motion again → verify brightness is NOT reset
- [ ] Light off → motion → verify it turns on at adaptive brightness
- [ ] Let light dim (wait for no-motion delay) → motion → verify full adaptive brightness is restored