### PR TITLE
Add study wall switch automation

### DIFF
--- a/home-assistant-amb/config/automation/switch_study.yaml
+++ b/home-assistant-amb/config/automation/switch_study.yaml
@@ -1,0 +1,9 @@
+- alias: Switch Wall Study
+  id: switch_wall_study
+  use_blueprint:
+    path: custom/hue_wall_switch_dim.yaml
+    input:
+      controller: Switch Wall Study
+      left_light:
+        - light.light_group_study
+      left_dim_direction_entity: input_text.dim_direction_switch_wall_study_left

--- a/home-assistant-amb/config/input_text.yaml
+++ b/home-assistant-amb/config/input_text.yaml
@@ -22,3 +22,8 @@ dim_direction_switch_wall_bedroom_duco_new_left:
   name: Dim direction Switch Wall Bedroom Duco New Left
   initial: "down_0"
   max: 30
+
+dim_direction_switch_wall_study_left:
+  name: Dim direction Switch Wall Study Left
+  initial: "down_0"
+  max: 30


### PR DESCRIPTION
## Summary
- Add wall switch automation for the study using the `hue_wall_switch_dim` blueprint
- Left button controls `light.light_group_study` with hold-to-dim support
- Add `input_text` dim direction helper for the left button

## Test plan
- [ ] Checkout branch on Raspberry Pi and reload automations
- [ ] Verify left short press toggles the study light on/off
- [ ] Verify left hold dims the study light up/down