### PR TITLE
Add bedroom JC evening light automations

### DIFF
--- a/home-assistant-amb/config/automation/light_bedroom_jc_evening.yaml
+++ b/home-assistant-amb/config/automation/light_bedroom_jc_evening.yaml
@@ -18,32 +18,20 @@
 
 - alias: "Light Bedroom JC Bed J midnight off"
   id: light-bedroom-jc-bed-j-midnight-off
-  trigger:
-    - platform: time
-      at: "00:00:00"
-  condition:
-    - condition: state
-      entity_id: light.light_bedroom_jc_bed_j
-      state: "on"
-  action:
-    - service: light.turn_off
-      data:
-        transition: 10
-      target:
-        entity_id: light.light_bedroom_jc_bed_j
+  use_blueprint:
+    path: custom/light_turn_off_at_time.yaml
+    input:
+      person_entity: person.jori
+      light_entity: light.light_bedroom_jc_bed_j
+      time: "00:00:00"
+      transition: 10
 
 - alias: "Light Bedroom JC Bed C midnight off"
   id: light-bedroom-jc-bed-c-midnight-off
-  trigger:
-    - platform: time
-      at: "00:00:00"
-  condition:
-    - condition: state
-      entity_id: light.light_bedroom_jc_bed_c
-      state: "on"
-  action:
-    - service: light.turn_off
-      data:
-        transition: 10
-      target:
-        entity_id: light.light_bedroom_jc_bed_c
+  use_blueprint:
+    path: custom/light_turn_off_at_time.yaml
+    input:
+      person_entity: person.chantal
+      light_entity: light.light_bedroom_jc_bed_c
+      time: "00:00:00"
+      transition: 10

--- a/home-assistant-amb/config/automation/light_bedroom_jc_evening.yaml
+++ b/home-assistant-amb/config/automation/light_bedroom_jc_evening.yaml
@@ -15,3 +15,35 @@
       person_entity: person.chantal
       light_entity: light.light_bedroom_jc_bed_c
       time: "21:00:00"
+
+- alias: "Light Bedroom JC Bed J midnight off"
+  id: light-bedroom-jc-bed-j-midnight-off
+  trigger:
+    - platform: time
+      at: "00:00:00"
+  condition:
+    - condition: state
+      entity_id: light.light_bedroom_jc_bed_j
+      state: "on"
+  action:
+    - service: light.turn_off
+      data:
+        transition: 10
+      target:
+        entity_id: light.light_bedroom_jc_bed_j
+
+- alias: "Light Bedroom JC Bed C midnight off"
+  id: light-bedroom-jc-bed-c-midnight-off
+  trigger:
+    - platform: time
+      at: "00:00:00"
+  condition:
+    - condition: state
+      entity_id: light.light_bedroom_jc_bed_c
+      state: "on"
+  action:
+    - service: light.turn_off
+      data:
+        transition: 10
+      target:
+        entity_id: light.light_bedroom_jc_bed_c

--- a/home-assistant-amb/config/automation/light_bedroom_jc_evening.yaml
+++ b/home-assistant-amb/config/automation/light_bedroom_jc_evening.yaml
@@ -16,6 +16,7 @@
       light_entity: light.light_bedroom_jc_bed_c
       time: "21:00:00"
 
+# Turn off at midnight if person left after 21:00 (light would stay on all night otherwise)
 - alias: "Light Bedroom JC Bed J midnight off"
   id: light-bedroom-jc-bed-j-midnight-off
   use_blueprint:

--- a/home-assistant-amb/config/automation/light_bedroom_jc_evening.yaml
+++ b/home-assistant-amb/config/automation/light_bedroom_jc_evening.yaml
@@ -1,0 +1,17 @@
+- alias: "Light Bedroom JC Bed J evening on"
+  id: light-bedroom-jc-bed-j-evening-on
+  use_blueprint:
+    path: custom/light_turn_on_at_time.yaml
+    input:
+      person_entity: person.jori
+      light_entity: light.light_bedroom_jc_bed_j
+      time: "21:00:00"
+
+- alias: "Light Bedroom JC Bed C evening on"
+  id: light-bedroom-jc-bed-c-evening-on
+  use_blueprint:
+    path: custom/light_turn_on_at_time.yaml
+    input:
+      person_entity: person.chantal
+      light_entity: light.light_bedroom_jc_bed_c
+      time: "21:00:00"

--- a/home-assistant-amb/config/blueprints/automation/custom/light_turn_off_at_time.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/light_turn_off_at_time.yaml
@@ -1,0 +1,56 @@
+blueprint:
+  name: Turn off light at time if person is not home
+  description: >
+    Turn off a light at a specified time if the person is not home
+    and the light is on.
+  domain: automation
+  input:
+    person_entity:
+      name: Person
+      description: Person entity to check presence for.
+      selector:
+        entity:
+          domain: person
+    light_entity:
+      name: Light
+      selector:
+        entity:
+          domain: light
+    time:
+      name: Time
+      description: Time at which to turn off the light.
+      selector:
+        time: {}
+    transition:
+      name: Transition
+      description: Transition time in seconds.
+      default: 5
+      selector:
+        number:
+          min: 0
+          max: 60
+          step: 1
+          unit_of_measurement: s
+
+mode: single
+
+trigger:
+  - platform: time
+    at: !input time
+
+condition:
+  - condition: not
+    conditions:
+      - condition: state
+        entity_id: !input person_entity
+        state: home
+  - condition: state
+    entity_id: !input light_entity
+    state: "on"
+
+action:
+  - service: light.turn_off
+    data:
+      transition: !input transition
+    target:
+      entity_id: !input light_entity

--- a/home-assistant-amb/config/blueprints/automation/custom/light_turn_on_at_time.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/light_turn_on_at_time.yaml
@@ -1,0 +1,45 @@
+blueprint:
+  name: Turn on light at time if person is home
+  description: >
+    Turn on a light at a specified time if a person is detected at home
+    and the light is not already on. Uses only a transition (no brightness
+    or color temperature) so that adaptive lighting can take over.
+  domain: automation
+  input:
+    person_entity:
+      name: Person
+      description: Person entity to check presence for.
+      selector:
+        entity:
+          domain: person
+    light_entity:
+      name: Light
+      selector:
+        entity:
+          domain: light
+    time:
+      name: Time
+      description: Time at which to turn on the light.
+      selector:
+        time: {}
+
+mode: single
+
+trigger:
+  - platform: time
+    at: !input time
+
+condition:
+  - condition: state
+    entity_id: !input person_entity
+    state: home
+  - condition: state
+    entity_id: !input light_entity
+    state: "off"
+
+action:
+  - service: light.turn_on
+    data:
+      transition: 5
+    target:
+      entity_id: !input light_entity


### PR DESCRIPTION
## Summary
- New blueprint `light_turn_on_at_time.yaml`: turns on a light at a specified time if a person is home and the light is not already on (transition only, no brightness/color_temp).
- New blueprint `light_turn_off_at_time.yaml`: turns off a light at a specified time if the person is not home and the light is on.
- Four automations for bedroom JC:
  - 21:00 turn on: `person.jori` → `light.light_bedroom_jc_bed_j`, `person.chantal` → `light.light_bedroom_jc_bed_c`
  - 00:00 turn off (if person not home): same pairings, 10s transition

## Test plan
- [x] CI passes config validation
- [x] Pull branch on Raspberry Pi and reload automations
- [x] Verify light turns on at 21:00 when person is home and light is off
- [x] Verify light does not turn on when person is away
- [x] Verify light does not turn on when already on
- [x] Verify light turns off at midnight when person is not home
- [x] Verify light stays on at midnight when person is home