### PR TITLE
Add bedroom JC light-on-arrival automations

### DIFF
--- a/home-assistant-amb/config/automation/light_bedroom_jc_evening.yaml
+++ b/home-assistant-amb/config/automation/light_bedroom_jc_evening.yaml
@@ -1,7 +1,7 @@
 - alias: "Light Bedroom JC Bed J evening on"
   id: light-bedroom-jc-bed-j-evening-on
   use_blueprint:
-    path: custom/light_turn_on_at_time.yaml
+    path: custom/bedside_light_on_at_time.yaml
     input:
       person_entity: person.jori
       light_entity: light.light_bedroom_jc_bed_j
@@ -10,7 +10,7 @@
 - alias: "Light Bedroom JC Bed C evening on"
   id: light-bedroom-jc-bed-c-evening-on
   use_blueprint:
-    path: custom/light_turn_on_at_time.yaml
+    path: custom/bedside_light_on_at_time.yaml
     input:
       person_entity: person.chantal
       light_entity: light.light_bedroom_jc_bed_c
@@ -20,7 +20,7 @@
 - alias: "Light Bedroom JC Bed J on when Jori arrives"
   id: light-bedroom-jc-bed-j-on-person-arrives
   use_blueprint:
-    path: custom/light_turn_on_person_arrives.yaml
+    path: custom/bedside_light_on_person_arrives.yaml
     input:
       person_entity: person.jori
       light_entity: light.light_bedroom_jc_bed_j
@@ -31,7 +31,7 @@
 - alias: "Light Bedroom JC Bed C on when Chantal arrives"
   id: light-bedroom-jc-bed-c-on-person-arrives
   use_blueprint:
-    path: custom/light_turn_on_person_arrives.yaml
+    path: custom/bedside_light_on_person_arrives.yaml
     input:
       person_entity: person.chantal
       light_entity: light.light_bedroom_jc_bed_c
@@ -43,7 +43,7 @@
 - alias: "Light Bedroom JC Bed J midnight off"
   id: light-bedroom-jc-bed-j-midnight-off
   use_blueprint:
-    path: custom/light_turn_off_at_time.yaml
+    path: custom/bedside_light_off_at_time.yaml
     input:
       person_entity: person.jori
       light_entity: light.light_bedroom_jc_bed_j
@@ -53,7 +53,7 @@
 - alias: "Light Bedroom JC Bed C midnight off"
   id: light-bedroom-jc-bed-c-midnight-off
   use_blueprint:
-    path: custom/light_turn_off_at_time.yaml
+    path: custom/bedside_light_off_at_time.yaml
     input:
       person_entity: person.chantal
       light_entity: light.light_bedroom_jc_bed_c

--- a/home-assistant-amb/config/automation/light_bedroom_jc_evening.yaml
+++ b/home-assistant-amb/config/automation/light_bedroom_jc_evening.yaml
@@ -16,6 +16,29 @@
       light_entity: light.light_bedroom_jc_bed_c
       time: "21:00:00"
 
+# Turn on when person arrives home 21:00-00:00 (only if the other person's light is still on)
+- alias: "Light Bedroom JC Bed J on when Jori arrives"
+  id: light-bedroom-jc-bed-j-on-person-arrives
+  use_blueprint:
+    path: custom/light_turn_on_person_arrives.yaml
+    input:
+      person_entity: person.jori
+      light_entity: light.light_bedroom_jc_bed_j
+      other_light_entity: light.light_bedroom_jc_bed_c
+      after_time: "21:00:00"
+      before_time: "00:00:00"
+
+- alias: "Light Bedroom JC Bed C on when Chantal arrives"
+  id: light-bedroom-jc-bed-c-on-person-arrives
+  use_blueprint:
+    path: custom/light_turn_on_person_arrives.yaml
+    input:
+      person_entity: person.chantal
+      light_entity: light.light_bedroom_jc_bed_c
+      other_light_entity: light.light_bedroom_jc_bed_j
+      after_time: "21:00:00"
+      before_time: "00:00:00"
+
 # Turn off at midnight if person left after 21:00 (light would stay on all night otherwise)
 - alias: "Light Bedroom JC Bed J midnight off"
   id: light-bedroom-jc-bed-j-midnight-off

--- a/home-assistant-amb/config/blueprints/automation/custom/bedside_light_off_at_time.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/bedside_light_off_at_time.yaml
@@ -1,8 +1,8 @@
 blueprint:
-  name: Turn off light at time if person is not home
+  name: Bedside light off at time
   description: >
-    Turn off a light at a specified time if the person is not home
-    and the light is on.
+    Turn off a bedside light at a specified time if the person is not
+    home and the light is on.
   domain: automation
   input:
     person_entity:

--- a/home-assistant-amb/config/blueprints/automation/custom/bedside_light_on_at_time.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/bedside_light_on_at_time.yaml
@@ -1,9 +1,8 @@
 blueprint:
-  name: Turn on light at time if person is home
+  name: Bedside light on at time
   description: >
-    Turn on a light at a specified time if a person is detected at home
-    and the light is not already on. Uses only a transition (no brightness
-    or color temperature) so that adaptive lighting can take over.
+    Turn on a bedside light at a specified time if the person is home
+    and the light is off.
   domain: automation
   input:
     person_entity:

--- a/home-assistant-amb/config/blueprints/automation/custom/bedside_light_on_person_arrives.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/bedside_light_on_person_arrives.yaml
@@ -1,9 +1,8 @@
 blueprint:
-  name: Turn on light when person arrives home
+  name: Bedside light on when person arrives
   description: >
-    Turn on a light when a person arrives home during a time window,
-    but only if another light is already on (indicating the other person
-    is present with their light on).
+    Turn on a bedside light when a person arrives home during a time
+    window, but only if the other bedside light is already on.
   domain: automation
   input:
     person_entity:

--- a/home-assistant-amb/config/blueprints/automation/custom/light_turn_on_person_arrives.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/light_turn_on_person_arrives.yaml
@@ -1,0 +1,62 @@
+blueprint:
+  name: Turn on light when person arrives home
+  description: >
+    Turn on a light when a person arrives home during a time window,
+    but only if another light is already on (indicating the other person
+    is present with their light on).
+  domain: automation
+  input:
+    person_entity:
+      name: Person
+      description: Person whose arrival triggers the light.
+      selector:
+        entity:
+          domain: person
+    light_entity:
+      name: Light
+      description: Light to turn on.
+      selector:
+        entity:
+          domain: light
+    other_light_entity:
+      name: Other light
+      description: The other person's light (must be on for this to trigger).
+      selector:
+        entity:
+          domain: light
+    after_time:
+      name: After
+      description: Start of time window.
+      selector:
+        time: {}
+    before_time:
+      name: Before
+      description: End of time window.
+      selector:
+        time: {}
+
+mode: single
+
+trigger:
+  - platform: state
+    entity_id: !input person_entity
+    from: away
+    to: home
+
+condition:
+  - condition: time
+    after: !input after_time
+    before: !input before_time
+  - condition: state
+    entity_id: !input other_light_entity
+    state: "on"
+  - condition: state
+    entity_id: !input light_entity
+    state: "off"
+
+action:
+  - service: light.turn_on
+    data:
+      transition: 5
+    target:
+      entity_id: !input light_entity


### PR DESCRIPTION
## Summary
- New blueprint `bedside_light_on_person_arrives.yaml`: turns on a bedside light when a person arrives home during a time window, only if the other bedside light is already on.
- Two automations for bedroom JC (21:00–00:00):
  - When Jori arrives and Chantal's light is on → turn on Jori's light
  - When Chantal arrives and Jori's light is on → turn on Chantal's light
- Renamed all bedside light blueprints from `light_turn_*` to `bedside_light_*` to reflect their specific purpose.

## Test plan
- [ ] CI passes config validation
- [ ] Pull branch on Raspberry Pi and reload automations
- [ ] Verify light turns on when person arrives home 21:00–00:00 and other light is on
- [ ] Verify light does not turn on if other light is off
- [ ] Verify light does not turn on outside the time window