### PR TITLE
Add central heating cabinet light with door sensor control

### DIFF
--- a/home-assistant-amb/config/adaptive_lighting.yaml
+++ b/home-assistant-amb/config/adaptive_lighting.yaml
@@ -60,6 +60,16 @@
   initial_transition: 2
   sleep_transition: 5
 
+- name: "central-heating"
+  lights: ["light.light_group_central_heating"]
+  min_brightness: 30
+  max_brightness: 70
+  sleep_brightness: 20
+  min_color_temp: 3000
+  max_color_temp: 4000
+  initial_transition: 2
+  sleep_transition: 5
+
 - name: "dining-table"
   lights: ["light.light_dining_table"]
   min_brightness: 100

--- a/home-assistant-amb/config/automation/light_adaptive_toggle.yaml
+++ b/home-assistant-amb/config/automation/light_adaptive_toggle.yaml
@@ -17,6 +17,7 @@
         - switch.adaptive_lighting_living_spot_dark_outside
         - switch.adaptive_lighting_living_white_cabinet
         - switch.adaptive_lighting_stair_cabinet
+        - switch.adaptive_lighting_central_heating
         - switch.adaptive_lighting_dining_table
         - switch.adaptive_lighting_kitchen_middle
         - switch.adaptive_lighting_kitchen_countertop

--- a/home-assistant-amb/config/automation/light_central_heating.yaml
+++ b/home-assistant-amb/config/automation/light_central_heating.yaml
@@ -1,0 +1,13 @@
+- alias: Central heating cabinet light on/off
+  id: central-heating-cabinet-light-on-off
+  trigger:
+    - platform: state
+      entity_id: binary_sensor.door_central_heating_contact
+      to:
+        - 'on'
+        - 'off'
+  action:
+    - service: "light.turn_{{ trigger.to_state.state }}"
+      target:
+        entity_id: light.light_group_central_heating
+  mode: restart

--- a/home-assistant-amb/config/automation/light_garden.yaml
+++ b/home-assistant-amb/config/automation/light_garden.yaml
@@ -12,7 +12,7 @@
     # Attempt to turn on lights when only one of us arrives home:
     - platform: state
       entity_id: person.jori
-      from: not_home 
+      from: not_home
       to: home
     - platform: state
       entity_id: person.chantal

--- a/home-assistant-amb/config/automation/sleep_mode.yaml
+++ b/home-assistant-amb/config/automation/sleep_mode.yaml
@@ -28,6 +28,7 @@
         - switch.adaptive_lighting_sleep_mode_kitchen_countertop
         - switch.adaptive_lighting_sleep_mode_toilet
         - switch.adaptive_lighting_sleep_mode_stair_cabinet
+        - switch.adaptive_lighting_sleep_mode_central_heating
         - switch.adaptive_lighting_sleep_mode_study
   mode: restart
 

--- a/home-assistant-amb/config/template/presence.yaml
+++ b/home-assistant-amb/config/template/presence.yaml
@@ -35,6 +35,17 @@
     auto_off:
       minutes: 1
 
+- triggers:
+  - trigger: state
+    entity_id: binary_sensor.door_central_heating_contact
+    to: "on"
+  binary_sensor:
+    unique_id: door_central_heating_contact_recent
+    name: Door Central Heating Contact Recent
+    state: "on"
+    auto_off:
+      minutes: 1
+
 # Helpers to make the presence house sensor only have to deal with bools
 - triggers:
   - trigger: state
@@ -66,6 +77,7 @@
           "binary_sensor.door_front_contact_recent",
           "binary_sensor.door_back_contact_recent",
           "binary_sensor.door_living_stair_cabinet_contact_recent",
+          "binary_sensor.door_central_heating_contact_recent",
           "binary_sensor.motion_garden_occupancy",
           "binary_sensor.motion_hall_0_occupancy",
           "binary_sensor.motion_stairs_0_occupancy",


### PR DESCRIPTION
## Summary

- Adds adaptive lighting config for `light.light_group_central_heating` (mirrors stair cabinet settings)
- Adds door-triggered on/off automation via `binary_sensor.door_central_heating_contact`
- Registers adaptive lighting and sleep mode switches in toggle automations
- Adds presence contribution: door open contributes to Ground Floor presence for 1 minute