### PR TITLE
Add attic and central heating temperature sensors to climate dashboard

### DIFF
--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -115,6 +115,22 @@ views:
         icon: mdi:box-shadow  # can be improved
         name: Storage
         color: brown
+      - type: entity
+        show_name: true
+        show_state: true
+        show_icon: true
+        entity: sensor.climate_attic_temperature
+        icon: mdi:home-roof
+        name: Attic
+        color: blue-grey
+      - type: entity
+        show_name: true
+        show_state: true
+        show_icon: true
+        entity: sensor.climate_central_heating_temperature
+        icon: mdi:radiator
+        name: Central Heating
+        color: deep-orange
     sections:
       - type: grid
         cards:
@@ -144,6 +160,10 @@ views:
                 name: Bedroom Duco
               - entity: sensor.climate_storage_temperature
                 name: Storage
+              - entity: sensor.climate_attic_temperature
+                name: Attic
+              - entity: sensor.climate_central_heating_temperature
+                name: Central Heating
             grid_options: &grid_options_temperature
               columns: full
               rows: 6

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -122,7 +122,7 @@ views:
         entity: sensor.climate_attic_temperature
         icon: mdi:home-roof
         name: Attic
-        color: blue-grey
+        color: blue
       - type: entity
         show_name: true
         show_state: true
@@ -130,7 +130,7 @@ views:
         entity: sensor.climate_central_heating_temperature
         icon: mdi:radiator
         name: Central Heating
-        color: deep-orange
+        color: green
     sections:
       - type: grid
         cards:
@@ -200,6 +200,10 @@ views:
                 name: Bedroom Duco
               - entity: sensor.climate_storage_humidity
                 name: Storage
+              - entity: sensor.climate_attic_humidity
+                name: Attic
+              - entity: sensor.climate_central_heating_humidity
+                name: Central Heating
             min_y_axis: &min_y_axis_humidity 30
             max_y_axis: &max_y_axis_humidity 80
             fit_y_data: true


### PR DESCRIPTION
## Summary

- Adds `sensor.climate_attic_temperature` and `sensor.climate_central_heating_temperature` to the Measurements tab of the climate dashboard
- Both sensors appear as badges and in the temperature history graphs (1 day and 1 week)
- No changes to the overview dashboard as requested