### PR TITLE
Put Hall 0 lights in a single row on overview dashboard

### DIFF
--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -12,21 +12,23 @@ views:
             heading: Hall 0 (Ground floor hall)
             heading_style: subtitle
             icon: mdi:coat-rack
-          - type: tile
-            name: Spot
-            entity: light.light_group_hall_0_spot
-            features:
-              - type: light-brightness
-          - type: tile
-            name: Wall
-            entity: light.light_hall_0_wall
-            features:
-              - type: light-brightness
-          - type: tile
-            name: Toilet
-            entity: light.light_toilet
-            features:
-              - type: light-brightness
+          - type: horizontal-stack
+            cards:
+              - type: tile
+                name: Spot
+                entity: light.light_group_hall_0_spot
+                features:
+                  - type: light-brightness
+              - type: tile
+                name: Wall
+                entity: light.light_hall_0_wall
+                features:
+                  - type: light-brightness
+              - type: tile
+                name: Toilet
+                entity: light.light_toilet
+                features:
+                  - type: light-brightness
           - type: heading
             heading: Living
             heading_style: subtitle

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -125,21 +125,17 @@ views:
             heading: Hall 0 (Ground floor hall)
             heading_style: subtitle
             icon: mdi:coat-rack
-          - type: tile
-            name: Spot
-            entity: light.light_group_hall_0_spot
-            grid_options:
-              columns: 4
-          - type: tile
-            name: Wall
-            entity: light.light_hall_0_wall
-            grid_options:
-              columns: 4
-          - type: tile
-            name: Toilet
-            entity: light.light_toilet
-            grid_options:
-              columns: 4
+          - type: horizontal-stack
+            cards:
+              - type: tile
+                name: Spot
+                entity: light.light_group_hall_0_spot
+              - type: tile
+                name: Wall
+                entity: light.light_hall_0_wall
+              - type: tile
+                name: Toilet
+                entity: light.light_toilet
           - type: heading
             heading: Living
             heading_style: subtitle

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -128,12 +128,18 @@ views:
           - type: tile
             name: Spot
             entity: light.light_group_hall_0_spot
+            grid_options:
+              columns: 4
           - type: tile
             name: Wall
             entity: light.light_hall_0_wall
+            grid_options:
+              columns: 4
           - type: tile
             name: Toilet
             entity: light.light_toilet
+            grid_options:
+              columns: 4
           - type: heading
             heading: Living
             heading_style: subtitle


### PR DESCRIPTION
## Summary
- Add `grid_options: columns: 4` to Spot, Wall, and Toilet tiles so all three fit in one row (4+4+4 = 12 columns)