### PR TITLE
Improve consistency between Overview and Lights dashboards

### DIFF
--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -107,9 +107,9 @@ views:
             color: green
             grid_options:
               columns: 12
-  - title: Lights
+  - title: Toggles
     path: main
-    icon: mdi:globe-light
+    icon: mdi:light-switch
     type: sections
     max_columns: 4
     sections:

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -1,4 +1,112 @@
 views:
+  - title: Wake up lights
+    path: wake-up-lights
+    icon: mdi:alarm-check
+    type: sections
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: Wake up light kids
+            heading_style: title
+
+          - type: heading
+            heading: Status
+            heading_style: subtitle
+          - type: tile
+            name: Olivier Color
+            entity: light.light_group_bedroom_olivier_color
+            tap_action:
+              action: none
+            icon_tap_action:
+              action: none
+          - type: tile
+            name: Duco Color
+            entity: light.light_group_bedroom_duco_color
+            tap_action:
+              action: none
+            icon_tap_action:
+              action: none
+          - type: tile
+            name: Wake up light in progress
+            entity: input_boolean.wake_up_lights_kids_cycle_in_progress
+            tap_action:
+              action: none
+            icon_tap_action:
+              action: none
+            grid_options:
+              columns: 12
+
+          - type: heading
+            heading: Actions
+            heading_style: subtitle
+          - type: tile
+            name: Start now
+            entity: automation.wake_up_light_kids
+            icon: mdi:play
+            color: deep-orange
+            hide_state: true
+            tap_action:
+              action: call-service
+              service: automation.trigger
+              service_data:
+                entity_id: automation.wake_up_light_kids
+            icon_tap_action:
+              action: none
+          - type: tile
+            name: Stop
+            entity: input_boolean.wake_up_lights_kids_cycle_in_progress
+            icon: mdi:stop
+            color: red
+            hide_state: true
+            tap_action:
+              action: call-service
+              service: script.wake_up_light_kids_stop_cycle
+            icon_tap_action:
+              action: none
+          - type: tile
+            name: Set to green
+            entity: automation.wake_up_light_kids
+            icon: mdi:lightbulb-on
+            color: green
+            hide_state: true
+            tap_action:
+              action: call-service
+              service: script.wake_up_light_kids_set_green
+            icon_tap_action:
+              action: none
+          - type: tile
+            name: Color lights off
+            entity: automation.wake_up_light_kids
+            icon: mdi:lightbulb-off
+            color: gray
+            hide_state: true
+            tap_action:
+              action: call-service
+              service: light.turn_off
+              service_data:
+                entity_id:
+                  - light.light_group_bedroom_duco_color
+                  - light.light_group_bedroom_olivier_color
+            icon_tap_action:
+              action: none
+
+          - type: heading
+            heading: Settings
+            heading_style: subtitle
+          - type: tile
+            name: Enabled
+            entity: input_boolean.wake_up_light_kids_enabled
+          - type: tile
+            name: Start (orange)
+            entity: input_datetime.wake_up_light_kids_start_orange
+            color: deep-orange
+          - type: tile
+            name: Minutes until green
+            entity: input_number.wake_up_light_kids_minutes_until_green
+            color: green
+            grid_options:
+              columns: 12
   - title: Lights
     path: main
     icon: mdi:globe-light
@@ -186,111 +294,22 @@ views:
             entity: input_boolean.adaptive_lighting
             tap_action:
               action: toggle
-  - title: Wake up lights
-    path: wake-up-lights
-    icon: mdi:alarm-check
-    type: sections
-    sections:
-      - type: grid
-        cards:
-          - type: heading
-            heading: Wake up light kids
-            heading_style: title
 
           - type: heading
-            heading: Status
+            heading: Illuminance
             heading_style: subtitle
-          - type: tile
-            name: Olivier Color
-            entity: light.light_group_bedroom_olivier_color
-            tap_action:
-              action: none
-            icon_tap_action:
-              action: none
-          - type: tile
-            name: Duco Color
-            entity: light.light_group_bedroom_duco_color
-            tap_action:
-              action: none
-            icon_tap_action:
-              action: none
-          - type: tile
-            name: Wake up light in progress
-            entity: input_boolean.wake_up_lights_kids_cycle_in_progress
-            tap_action:
-              action: none
-            icon_tap_action:
-              action: none
+            icon: mdi:weather-sunny
+          - type: history-graph
+            entities:
+              - entity: sensor.motion_garden_illuminance
+                name: Illuminance (raw)
+              - entity: sensor.motion_garden_illuminance_filtered
+                name: Illuminance (filtered)
+              - entity: input_number.illuminance_threshold_indoor_lights
+                name: Thr. indoor
+              - entity: input_number.illuminance_threshold_outdoor_lights
+                name: Thr. outdoor
+            hours_to_show: 24
             grid_options:
               columns: 12
-
-          - type: heading
-            heading: Actions
-            heading_style: subtitle
-          - type: tile
-            name: Start now
-            entity: automation.wake_up_light_kids
-            icon: mdi:play
-            color: deep-orange
-            hide_state: true
-            tap_action:
-              action: call-service
-              service: automation.trigger
-              service_data:
-                entity_id: automation.wake_up_light_kids
-            icon_tap_action:
-              action: none
-          - type: tile
-            name: Stop
-            entity: input_boolean.wake_up_lights_kids_cycle_in_progress
-            icon: mdi:stop
-            color: red
-            hide_state: true
-            tap_action:
-              action: call-service
-              service: script.wake_up_light_kids_stop_cycle
-            icon_tap_action:
-              action: none
-          - type: tile
-            name: Set to green
-            entity: automation.wake_up_light_kids
-            icon: mdi:lightbulb-on
-            color: green
-            hide_state: true
-            tap_action:
-              action: call-service
-              service: script.wake_up_light_kids_set_green
-            icon_tap_action:
-              action: none
-          - type: tile
-            name: Color lights off
-            entity: automation.wake_up_light_kids
-            icon: mdi:lightbulb-off
-            color: gray
-            hide_state: true
-            tap_action:
-              action: call-service
-              service: light.turn_off
-              service_data:
-                entity_id:
-                  - light.light_group_bedroom_duco_color
-                  - light.light_group_bedroom_olivier_color
-            icon_tap_action:
-              action: none
-
-          - type: heading
-            heading: Settings
-            heading_style: subtitle
-          - type: tile
-            name: Enabled
-            entity: input_boolean.wake_up_light_kids_enabled
-          - type: tile
-            name: Start (orange)
-            entity: input_datetime.wake_up_light_kids_start_orange
-            color: deep-orange
-          - type: tile
-            name: Minutes until green
-            entity: input_number.wake_up_light_kids_minutes_until_green
-            color: green
-            grid_options:
-              columns: 12
+              rows: 4

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -298,27 +298,16 @@ views:
   - title: Illuminance
     path: illuminance
     icon: mdi:weather-sunny
-    type: sections
-    max_columns: 4
-    sections:
-      - type: grid
-        column_span: 4
-        cards:
-          - type: heading
-            heading: Illuminance
-            heading_style: title
-            icon: mdi:weather-sunny
-          - type: history-graph
-            entities:
-              - entity: sensor.motion_garden_illuminance
-                name: Illuminance (raw)
-              - entity: sensor.motion_garden_illuminance_filtered
-                name: Illuminance (filtered)
-              - entity: input_number.illuminance_threshold_indoor_lights
-                name: Thr. indoor
-              - entity: input_number.illuminance_threshold_outdoor_lights
-                name: Thr. outdoor
-            hours_to_show: 24
-            grid_options:
-              columns: 12
-              rows: 8
+    type: panel
+    cards:
+      - type: history-graph
+        entities:
+          - entity: sensor.motion_garden_illuminance
+            name: Illuminance (raw)
+          - entity: sensor.motion_garden_illuminance_filtered
+            name: Illuminance (filtered)
+          - entity: input_number.illuminance_threshold_indoor_lights
+            name: Thr. indoor
+          - entity: input_number.illuminance_threshold_outdoor_lights
+            name: Thr. outdoor
+        hours_to_show: 24

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -286,15 +286,6 @@ views:
             features:
               - type: light-brightness
 
-          - type: heading
-            heading: Light automation
-            heading_style: subtitle
-            icon: mdi:robot
-          - type: tile
-            entity: input_boolean.adaptive_lighting
-            tap_action:
-              action: toggle
-
   - title: Illuminance
     path: illuminance
     icon: mdi:weather-sunny
@@ -311,3 +302,14 @@ views:
           - entity: input_number.illuminance_threshold_outdoor_lights
             name: Thr. outdoor
         hours_to_show: 24
+  - title: Light automation
+    path: light-automation
+    icon: mdi:robot
+    type: sections
+    sections:
+      - type: grid
+        cards:
+          - type: tile
+            entity: input_boolean.adaptive_lighting
+            tap_action:
+              action: toggle

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -299,10 +299,10 @@ views:
     path: illuminance
     icon: mdi:weather-sunny
     type: sections
-    max_columns: 1
+    max_columns: 4
     sections:
       - type: grid
-        column_span: 1
+        column_span: 4
         cards:
           - type: heading
             heading: Illuminance

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -319,4 +319,4 @@ views:
             hours_to_show: 24
             grid_options:
               columns: 12
-              rows: 4
+              rows: 8

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -108,7 +108,7 @@ views:
             grid_options:
               columns: 12
   - title: Toggles
-    path: main
+    path: toggles
     icon: mdi:light-switch
     type: sections
     max_columns: 4

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -295,9 +295,16 @@ views:
             tap_action:
               action: toggle
 
+  - title: Illuminance
+    path: illuminance
+    icon: mdi:weather-sunny
+    type: sections
+    sections:
+      - type: grid
+        cards:
           - type: heading
             heading: Illuminance
-            heading_style: subtitle
+            heading_style: title
             icon: mdi:weather-sunny
           - type: history-graph
             entities:

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -299,8 +299,10 @@ views:
     path: illuminance
     icon: mdi:weather-sunny
     type: sections
+    max_columns: 1
     sections:
       - type: grid
+        column_span: 1
         cards:
           - type: heading
             heading: Illuminance

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -122,6 +122,36 @@ views:
               action: navigate
               navigation_path: /dashboard-lights
           - type: heading
+            heading: Wake up lights
+            heading_style: subtitle
+            icon: mdi:alarm-check
+            tap_action:
+              action: navigate
+              navigation_path: /dashboard-lights/wake-up-lights
+          - type: tile
+            name: Enabled
+            entity: input_boolean.wake_up_light_kids_enabled
+            tap_action:
+              action: none
+            icon_tap_action:
+              action: none
+          - type: tile
+            name: Start (orange)
+            entity: input_datetime.wake_up_light_kids_start_orange
+            color: deep-orange
+            tap_action:
+              action: none
+            icon_tap_action:
+              action: none
+          - type: tile
+            name: Minutes until green
+            entity: input_number.wake_up_light_kids_minutes_until_green
+            color: green
+            tap_action:
+              action: none
+            icon_tap_action:
+              action: none
+          - type: heading
             heading: Hall 0 (Ground floor hall)
             heading_style: subtitle
             icon: mdi:coat-rack
@@ -216,7 +246,8 @@ views:
 
           - type: heading
             heading: Illuminance
-            heading_style: title
+            heading_style: subtitle
+            icon: mdi:weather-sunny
           - type: history-graph
             entities:
               - entity: sensor.motion_garden_illuminance_filtered

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -128,6 +128,10 @@ views:
             tap_action:
               action: navigate
               navigation_path: /dashboard-lights/wake-up-lights
+          - type: markdown
+            content: "Read-only. Tap heading to modify."
+            grid_options:
+              columns: 12
           - type: tile
             name: Enabled
             entity: input_boolean.wake_up_light_kids_enabled

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -122,35 +122,25 @@ views:
               action: navigate
               navigation_path: /dashboard-lights
           - type: heading
-            heading: "Wake up lights (read-only, tap to edit)"
+            heading: Wake up lights
             heading_style: subtitle
             icon: mdi:alarm-check
             tap_action:
               action: navigate
               navigation_path: /dashboard-lights/wake-up-lights
-          - type: tile
-            name: Enabled
-            entity: input_boolean.wake_up_light_kids_enabled
-            tap_action:
-              action: none
-            icon_tap_action:
-              action: none
-          - type: tile
-            name: Start (orange)
-            entity: input_datetime.wake_up_light_kids_start_orange
-            color: deep-orange
-            tap_action:
-              action: none
-            icon_tap_action:
-              action: none
-          - type: tile
-            name: Minutes until green
-            entity: input_number.wake_up_light_kids_minutes_until_green
-            color: green
-            tap_action:
-              action: none
-            icon_tap_action:
-              action: none
+          - type: horizontal-stack
+            cards:
+              - type: tile
+                name: Enabled
+                entity: input_boolean.wake_up_light_kids_enabled
+              - type: tile
+                name: Start
+                entity: input_datetime.wake_up_light_kids_start_orange
+                color: deep-orange
+              - type: tile
+                name: Min. to green
+                entity: input_number.wake_up_light_kids_minutes_until_green
+                color: green
           - type: heading
             heading: Hall 0 (Ground floor hall)
             heading_style: subtitle

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -122,16 +122,12 @@ views:
               action: navigate
               navigation_path: /dashboard-lights
           - type: heading
-            heading: Wake up lights
+            heading: "Wake up lights (read-only, tap to edit)"
             heading_style: subtitle
             icon: mdi:alarm-check
             tap_action:
               action: navigate
               navigation_path: /dashboard-lights/wake-up-lights
-          - type: markdown
-            content: "Read-only. Tap heading to modify."
-            grid_options:
-              columns: 12
           - type: tile
             name: Enabled
             entity: input_boolean.wake_up_light_kids_enabled

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -144,7 +144,7 @@ views:
             icon: mdi:light-switch
             tap_action:
               action: navigate
-              navigation_path: /dashboard-lights
+              navigation_path: /dashboard-lights/toggles
           - type: tile
             name: Living Spot Always
             entity: light.light_group_living_spot_always

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -248,6 +248,9 @@ views:
             heading: Illuminance
             heading_style: subtitle
             icon: mdi:weather-sunny
+            tap_action:
+              action: navigate
+              navigation_path: /dashboard-lights/illuminance
           - type: history-graph
             entities:
               - entity: sensor.motion_garden_illuminance_filtered

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -118,9 +118,6 @@ views:
             heading: Lights
             heading_style: title
             icon: mdi:globe-light
-            tap_action:
-              action: navigate
-              navigation_path: /dashboard-lights
           - type: heading
             heading: Wake up lights
             heading_style: subtitle
@@ -142,85 +139,21 @@ views:
                 entity: input_number.wake_up_light_kids_minutes_until_green
                 color: green
           - type: heading
-            heading: Hall 0 (Ground floor hall)
+            heading: Toggles
             heading_style: subtitle
-            icon: mdi:coat-rack
-          - type: horizontal-stack
-            cards:
-              - type: tile
-                name: Spot
-                entity: light.light_group_hall_0_spot
-              - type: tile
-                name: Wall
-                entity: light.light_hall_0_wall
-              - type: tile
-                name: Toilet
-                entity: light.light_toilet
-          - type: heading
-            heading: Living
-            heading_style: subtitle
-            icon: mdi:sofa
+            icon: mdi:light-switch
+            tap_action:
+              action: navigate
+              navigation_path: /dashboard-lights
           - type: tile
-            name: Spot Always
+            name: Living Spot Always
             entity: light.light_group_living_spot_always
           - type: tile
-            name: Spot Dark Outside
+            name: Living Spot Dark
             entity: light.light_group_living_spot_dark_outside
-          - type: tile
-            name: White Cabinet
-            entity: light.light_living_white_cabinet
-          - type: tile
-            name: Dining Table
-            entity: light.light_dining_table
-          - type: tile
-            name: Go
-            entity: light.light_go
-          - type: heading
-            heading: Kitchen
-            heading_style: subtitle
-            icon: mdi:fridge
-          - type: tile
-            name: Middle
-            entity: light.light_group_kitchen_middle
-          - type: tile
-            name: Countertop
-            entity: light.light_group_kitchen_countertop
-          - type: heading
-            heading: Bathroom
-            heading_style: subtitle
-            icon: mdi:shower-head
           - type: tile
             name: Bathroom
             entity: light.light_bathroom
-          - type: heading
-            heading: Bedrooms
-            heading_style: subtitle
-            icon: mdi:bed
-          - type: tile
-            name: Duco Ambiance
-            entity: light.light_group_bedroom_duco_ambiance
-          - type: tile
-            name: Duco Color
-            entity: light.light_group_bedroom_duco_color
-          - type: tile
-            name: Duco New
-            entity: light.light_group_bedroom_duco_new
-          - type: tile
-            name: Olivier Ambiance
-            entity: light.light_group_bedroom_olivier_ambiance
-          - type: tile
-            name: Olivier Color
-            entity: light.light_group_bedroom_olivier_color
-          - type: tile
-            name: Jori
-            entity: light.light_bedroom_jc_bed_j
-          - type: tile
-            name: Chantal
-            entity: light.light_bedroom_jc_bed_c
-          - type: heading
-            heading: Study
-            heading_style: subtitle
-            icon: mdi:desk
           - type: tile
             name: Study
             entity: light.light_group_study

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -159,15 +159,6 @@ views:
             entity: light.light_group_study
 
           - type: heading
-            heading: Light automation
-            heading_style: subtitle
-            icon: mdi:robot
-          - type: tile
-            entity: input_boolean.adaptive_lighting
-            tap_action:
-              action: toggle
-
-          - type: heading
             heading: Illuminance
             heading_style: subtitle
             icon: mdi:weather-sunny


### PR DESCRIPTION
## Summary
- Add wake-up lights summary (read-only tiles with navigate link) to overview page, positioned above all lights
- Move wake-up lights to first tab in lights dashboard to match overview ordering
- Demote illuminance heading from title to subtitle in overview (now a sub-section of Lights)
- Add illuminance section to lights dashboard with both raw and filtered sensors

## Test plan
- [ ] Checkout branch on Raspberry Pi and reload dashboards
- [ ] Verify overview shows wake-up lights section with read-only tiles that navigate to lights dashboard
- [ ] Verify lights dashboard has wake-up lights as the first tab
- [ ] Verify illuminance appears as subtitle under Lights in overview
- [ ] Verify illuminance section in lights dashboard shows both raw and filtered sensors