### PR TITLE
Add adaptive lighting config for Bedroom Duco New

### DIFF
--- a/home-assistant-amb/config/adaptive_lighting.yaml
+++ b/home-assistant-amb/config/adaptive_lighting.yaml
@@ -141,6 +141,14 @@
   max_sunset_time: "19:00:00"
   sleep_transition: 5
 
+- name: "bedroom-duco-new"
+  lights: ["light.light_group_bedroom_duco_new"]
+  min_brightness: 50
+  max_brightness: 50
+  min_color_temp: 2700
+  max_color_temp: 4000
+  sleep_transition: 5
+
 - name: "study"
   lights: ["light.light_group_study"]
   min_brightness: 50

--- a/home-assistant-amb/config/automation/light_adaptive_toggle.yaml
+++ b/home-assistant-amb/config/automation/light_adaptive_toggle.yaml
@@ -24,6 +24,7 @@
         - switch.adaptive_lighting_bathroom
         - switch.adaptive_lighting_bedroom_duco_ambiance
         - switch.adaptive_lighting_bedroom_duco_color
+        - switch.adaptive_lighting_bedroom_duco_new
         - switch.adaptive_lighting_bedroom_olivier_ambiance
         - switch.adaptive_lighting_bedroom_olivier_color
         - switch.adaptive_lighting_study

--- a/home-assistant-amb/config/automation/sleep_mode.yaml
+++ b/home-assistant-amb/config/automation/sleep_mode.yaml
@@ -10,26 +10,30 @@
   action:
     - service: "switch.turn_{{ sleep_mode }}"
       entity_id:
-        - switch.adaptive_lighting_sleep_mode_bathroom
         - switch.adaptive_lighting_sleep_mode_hall_0_spot
         - switch.adaptive_lighting_sleep_mode_hall_0_wall
+        - switch.adaptive_lighting_sleep_mode_kitchen_middle
+        - switch.adaptive_lighting_sleep_mode_kitchen_countertop
     # Use some delays to prevent flooding the Zigbee network
     - delay: "00:00:01"
     - service: "switch.turn_{{ sleep_mode }}"
       entity_id:
         - switch.adaptive_lighting_sleep_mode_living_spot_always
         - switch.adaptive_lighting_sleep_mode_living_spot_dark_outside
-        - switch.adaptive_lighting_sleep_mode_living_white_cabinet
         - switch.adaptive_lighting_sleep_mode_dining_table
     - delay: "00:00:01"
     - service: "switch.turn_{{ sleep_mode }}"
       entity_id:
-        - switch.adaptive_lighting_sleep_mode_kitchen_middle
-        - switch.adaptive_lighting_sleep_mode_kitchen_countertop
         - switch.adaptive_lighting_sleep_mode_toilet
         - switch.adaptive_lighting_sleep_mode_stair_cabinet
+        - switch.adaptive_lighting_sleep_mode_bathroom
+    - delay: "00:00:01"
+    - service: "switch.turn_{{ sleep_mode }}"
+      entity_id:
         - switch.adaptive_lighting_sleep_mode_central_heating
         - switch.adaptive_lighting_sleep_mode_study
+        - switch.adaptive_lighting_sleep_mode_bedroom_duco_new
+        - switch.adaptive_lighting_sleep_mode_living_white_cabinet
   mode: restart
 
 - alias: "Sleep mode: scheduled on"


### PR DESCRIPTION
## Summary
- Add adaptive lighting entry for Bedroom Duco New with same settings as study (brightness 50/50, color temp 2700-4000K)
- Register in adaptive lighting toggle automation
- Add to sleep mode (non-kids) with rearranged activation order

## Test plan
- [ ] Verify CI passes
- [ ] Check on live HA that the new adaptive lighting switch appears and controls the light