### PR TITLE
Rename Climate Storage to Climate Bedroom Duco

### DIFF
--- a/home-assistant-amb/config/automation/heating_needed_alert.yaml
+++ b/home-assistant-amb/config/automation/heating_needed_alert.yaml
@@ -42,10 +42,10 @@
       temperature_sensor: sensor.climate_study_temperature
       room_name: "Study"
 
-- alias: "Heating needed alert - Storage"
-  id: heating-needed-alert-storage
+- alias: "Heating needed alert - Bedroom Duco"
+  id: heating-needed-alert-bedroom-duco
   use_blueprint:
     path: custom/heating_needed_alert.yaml
     input:
-      temperature_sensor: sensor.climate_storage_temperature
-      room_name: "Storage"
+      temperature_sensor: sensor.climate_bedroom_duco_temperature
+      room_name: "Bedroom Duco"

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -111,9 +111,9 @@ views:
         show_name: true
         show_state: true
         show_icon: true
-        entity: sensor.climate_storage_temperature
-        icon: mdi:box-shadow  # can be improved
-        name: Storage
+        entity: sensor.climate_bedroom_duco_temperature
+        icon: mdi:bed
+        name: Bedroom Duco
         color: brown
       - type: entity
         show_name: true
@@ -158,8 +158,8 @@ views:
                 name: Bedroom Olivier
               - entity: sensor.climate_laundry_temperature
                 name: Laundry
-              - entity: sensor.climate_storage_temperature
-                name: Storage
+              - entity: sensor.climate_bedroom_duco_temperature
+                name: Bedroom Duco
               - entity: sensor.climate_attic_temperature
                 name: Attic
               - entity: sensor.climate_central_heating_temperature
@@ -198,8 +198,8 @@ views:
                 name: Bedroom Olivier
               - entity: sensor.climate_laundry_humidity
                 name: Laundry
-              - entity: sensor.climate_storage_humidity
-                name: Storage
+              - entity: sensor.climate_bedroom_duco_humidity
+                name: Bedroom Duco
               - entity: sensor.climate_attic_humidity
                 name: Attic
               - entity: sensor.climate_central_heating_humidity


### PR DESCRIPTION
## Summary
- Rename zigbee2mqtt device friendly name from "Climate Storage" to "Climate Bedroom Duco"
- Update all entity references in the climate dashboard and heating alert automation
- Change dashboard icon from `mdi:box-shadow` to `mdi:bed`