### PR TITLE
Rename Bedroom Duco New to Bedroom Duco

### DIFF
--- a/home-assistant-amb/config/adaptive_lighting.yaml
+++ b/home-assistant-amb/config/adaptive_lighting.yaml
@@ -126,8 +126,8 @@
   max_sunset_time: "19:00:00"
   sleep_transition: 5
 
-- name: "bedroom-duco-new"
-  lights: ["light.light_group_bedroom_duco_new"]
+- name: "bedroom-duco"
+  lights: ["light.light_group_bedroom_duco"]
   min_brightness: 40
   max_brightness: 40
   min_color_temp: 2700

--- a/home-assistant-amb/config/automation/light_adaptive_toggle.yaml
+++ b/home-assistant-amb/config/automation/light_adaptive_toggle.yaml
@@ -24,7 +24,7 @@
         - switch.adaptive_lighting_bathroom
         - switch.adaptive_lighting_laundry_ambiance
         - switch.adaptive_lighting_laundry_color
-        - switch.adaptive_lighting_bedroom_duco_new
+        - switch.adaptive_lighting_bedroom_duco
         - switch.adaptive_lighting_bedroom_olivier_ambiance
         - switch.adaptive_lighting_bedroom_olivier_color
         - switch.adaptive_lighting_study

--- a/home-assistant-amb/config/automation/sleep_mode.yaml
+++ b/home-assistant-amb/config/automation/sleep_mode.yaml
@@ -32,7 +32,7 @@
       entity_id:
         - switch.adaptive_lighting_sleep_mode_central_heating
         - switch.adaptive_lighting_sleep_mode_study
-        - switch.adaptive_lighting_sleep_mode_bedroom_duco_new
+        - switch.adaptive_lighting_sleep_mode_bedroom_duco
         - switch.adaptive_lighting_sleep_mode_living_white_cabinet
   mode: restart
 

--- a/home-assistant-amb/config/automation/switch_bedroom_duco.yaml
+++ b/home-assistant-amb/config/automation/switch_bedroom_duco.yaml
@@ -1,0 +1,9 @@
+- alias: Switch Wall Bedroom Duco
+  id: switch_wall_bedroom_duco
+  use_blueprint:
+    path: custom/hue_wall_switch_dim.yaml
+    input:
+      controller: Switch Wall Bedroom Duco
+      left_light:
+        - light.light_group_bedroom_duco
+      left_dim_direction_entity: input_text.dim_direction_switch_wall_bedroom_duco_left

--- a/home-assistant-amb/config/automation/switch_bedroom_duco_new.yaml
+++ b/home-assistant-amb/config/automation/switch_bedroom_duco_new.yaml
@@ -1,9 +1,0 @@
-- alias: Switch Wall Bedroom Duco New
-  id: switch_wall_bedroom_duco_new
-  use_blueprint:
-    path: custom/hue_wall_switch_dim.yaml
-    input:
-      controller: Switch Wall Bedroom Duco New
-      left_light:
-        - light.light_group_bedroom_duco_new
-      left_dim_direction_entity: input_text.dim_direction_switch_wall_bedroom_duco_new_left

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -252,12 +252,12 @@ views:
             entity: input_boolean.disco_laundry
 
           - type: heading
-            heading: Bedroom Duco New
+            heading: Bedroom Duco
             heading_style: subtitle
             icon: mdi:bed
           - type: tile
-            name: Bedroom Duco New
-            entity: light.light_group_bedroom_duco_new
+            name: Bedroom Duco
+            entity: light.light_group_bedroom_duco
             features:
               - type: light-brightness
 

--- a/home-assistant-amb/config/input_text.yaml
+++ b/home-assistant-amb/config/input_text.yaml
@@ -18,8 +18,8 @@ dim_direction_switch_wall_living_right:
   initial: "down_0"
   max: 30
 
-dim_direction_switch_wall_bedroom_duco_new_left:
-  name: Dim direction Switch Wall Bedroom Duco New Left
+dim_direction_switch_wall_bedroom_duco_left:
+  name: Dim direction Switch Wall Bedroom Duco Left
   initial: "down_0"
   max: 30
 

--- a/zigbee2mqtt-amb/zigbee2mqtt-data/configuration.yaml
+++ b/zigbee2mqtt-amb/zigbee2mqtt-data/configuration.yaml
@@ -169,7 +169,7 @@ devices:
   '0x001788010eed6db0':
     friendly_name: Light Living Wall Left 1
   '0x001788010eed5e3b':
-    friendly_name: Light Bedroom Duco New 1
+    friendly_name: Light Bedroom Duco 1
   '0x001788010efd454a':
     friendly_name: Light Go
     availability: false
@@ -211,19 +211,19 @@ devices:
   '0x001788010fa65e29':
     friendly_name: Light Study 6
   '0x001788010cc29e08':
-    friendly_name: Switch Wall Bedroom Duco New
+    friendly_name: Switch Wall Bedroom Duco
   '0x001788010fa9c4cb':
-    friendly_name: Light Bedroom Duco New 3
+    friendly_name: Light Bedroom Duco 3
   '0x001788010fa9c4a2':
-    friendly_name: Light Bedroom Duco New 4
+    friendly_name: Light Bedroom Duco 4
   '0x001788010fa4901f':
-    friendly_name: Light Bedroom Duco New 5
+    friendly_name: Light Bedroom Duco 5
   '0x001788010fae25e0':
-    friendly_name: Light Bedroom Duco New 6
+    friendly_name: Light Bedroom Duco 6
   '0x001788010fa49026':
-    friendly_name: Light Bedroom Duco New 7
+    friendly_name: Light Bedroom Duco 7
   '0x001788010fac52aa':
-    friendly_name: Light Bedroom Duco New 8
+    friendly_name: Light Bedroom Duco 8
   '0x001788010cc472d2':
     friendly_name: Switch Wall Study
   '0x00158d008c7ee9f4':
@@ -239,7 +239,7 @@ devices:
   '0x001788010fa7141d':
     friendly_name: Light Central Heating 3
   '0x001788010fa7304a':
-    friendly_name: Light Bedroom Duco New 2
+    friendly_name: Light Bedroom Duco 2
   '0x001788010fb6593c':
     friendly_name: Light Laundry 2
 groups:
@@ -270,7 +270,7 @@ groups:
   '13':
     friendly_name: Light Group Study
   '14':
-    friendly_name: Light Group Bedroom Duco New
+    friendly_name: Light Group Bedroom Duco
   '15':
     friendly_name: Light Group Kitchen
   '16':


### PR DESCRIPTION
## Summary
- Rename all references from "Bedroom Duco New" to "Bedroom Duco" across HA config, automations, dashboard, and zigbee2mqtt