### PR TITLE
Upgrade Home Assistant to 2026.5.2 and remove ha-illuminance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,8 @@ just build              # Build Docker image with custom components
 just test               # Validate Home Assistant configuration (requires Docker)
 ```
 
-The build process creates a custom Docker image based on `ghcr.io/home-assistant/home-assistant:2026.4.3` with two baked-in custom components:
+The build process creates a custom Docker image based on `ghcr.io/home-assistant/home-assistant:2026.5.2` with one baked-in custom component:
 - **adaptive-lighting**: Dynamic light color/brightness adjustment
-- **ha-illuminance**: Light level calculations based on weather/sun position
 
 ### Pre-commit Hooks
 
@@ -54,7 +53,6 @@ Home Assistant config uses a split configuration model (see `home-assistant-amb/
   - `script.yaml`: Scripts
   - `binary_sensor.yaml`: Binary sensor definitions
   - `adaptive_lighting.yaml`: Adaptive lighting configurations for each light/room
-  - `illuminance.yaml`: Illuminance sensor definitions
 
 ### Custom Components Symlink Pattern
 
@@ -90,7 +88,6 @@ The Dockerfile installs custom components to `/custom_components`. The mounted c
 **Dark Awareness**: Binary sensors in `template/dark.yaml`:
 - `Sufficiently Dark For Indoor Lights`: Illuminance < threshold (uses `motion_garden_illuminance_filtered`)
 - `Sufficiently Dark For Outdoor Lights`: Illuminance < lower threshold
-- Uses ha-illuminance component which combines sun elevation + weather cloud coverage
 
 ### CI/CD
 

--- a/home-assistant-amb/config/configuration.yaml
+++ b/home-assistant-amb/config/configuration.yaml
@@ -30,4 +30,3 @@ binary_sensor: !include binary_sensor.yaml
 
 # Custom component config files to include
 adaptive_lighting: !include adaptive_lighting.yaml
-illuminance: !include illuminance.yaml

--- a/home-assistant-amb/config/illuminance.yaml
+++ b/home-assistant-amb/config/illuminance.yaml
@@ -1,6 +1,0 @@
-- unique_id: illuminance-cloud-coverage
-  name: Illuminance Cloud Coverage
-  entity_id: sensor.weather_cloud_coverage
-
-- unique_id: illuminance-weatherless
-  name: Illuminance Weatherless

--- a/home-assistant-amb/config/template/dark.yaml
+++ b/home-assistant-amb/config/template/dark.yaml
@@ -1,7 +1,4 @@
 - binary_sensor:
-    # These sensors rely on ha-illuminance custom component that combines elevation data with weather data,
-    # such that dark rainy/cloudy conditions may turn on lights.
-
     - name: Sufficiently Dark For Indoor Lights
       unique_id: sufficiently_dark_for_indoor_lights
       icon: mdi:moon-waning-crescent

--- a/home-assistant-amb/docker/Dockerfile
+++ b/home-assistant-amb/docker/Dockerfile
@@ -1,7 +1,6 @@
-FROM ghcr.io/home-assistant/home-assistant:2026.4.3
+FROM ghcr.io/home-assistant/home-assistant:2026.5.2
 
 ARG ADAPTIVE_LIGHTING_VERSION=1.30.1
-ARG HA_ILLUMINANCE_VERSION=5.7.0
 
 # Setup alternative custom_components directory.
 # Home Assistant expects this in /config/custom_components, but I want to mount the entire config
@@ -15,10 +14,3 @@ RUN cd /tmp \
 	&& unzip adaptive-lighting.zip \
 	&& mv adaptive-lighting-${ADAPTIVE_LIGHTING_VERSION}/custom_components/adaptive_lighting ${CUSTOM_COMPONENTS_DIR} \
 	&& rm -rf /tmp/*
-
-# Add ha-illuminance
-RUN cd /tmp \
-    && wget -O ha-illuminance.zip https://github.com/pnbruckner/ha-illuminance/archive/refs/tags/${HA_ILLUMINANCE_VERSION}.zip \
-    && unzip ha-illuminance.zip \
-    && mv ha-illuminance-${HA_ILLUMINANCE_VERSION}/custom_components/illuminance ${CUSTOM_COMPONENTS_DIR} \
-    && rm -rf /tmp/*


### PR DESCRIPTION
## Summary
- Upgrades Home Assistant from 2026.4.3 to 2026.5.2
- Removes the ha-illuminance custom component — it computed illuminance from sun elevation + weather data, but reported values that were way too high and often didn't account for clouds/rain. Replaced by an outdoor motion sensor (motion_garden) that reports illuminance directly and much more reliably.
- Removes `illuminance.yaml` config and its reference in `configuration.yaml`

## Test plan
- [x] `just build` succeeds
- [x] `just test` (config validation) passes
- [x] Deploy on Raspberry Pi with `docker compose up -d --build` and verify dark-awareness automations still trigger correctly