### PR TITLE
Replace thermostat cards with tile cards

### DIFF
--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -27,21 +27,18 @@ views:
             heading: Thermostats
             heading_style: title
             icon: mdi:thermostat
-          - type: thermostat
+          - type: tile
             entity: climate.living
-            grid_options:
-              rows: 3
-              columns: 6
-          - type: thermostat
+            features:
+              - type: target-temperature
+          - type: tile
             entity: climate.study
-            grid_options:
-              rows: 3
-              columns: 6
-          - type: thermostat
+            features:
+              - type: target-temperature
+          - type: tile
             entity: climate.bedroom_jc
-            grid_options:
-              rows: 3
-              columns: 6
+            features:
+              - type: target-temperature
           - type: heading
             heading: Heating percentage 24h
             heading_style: subtitle

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -200,16 +200,14 @@ views:
             tap_action:
               action: navigate
               navigation_path: /dashboard-climate/thermostats
-          - type: thermostat
+          - type: tile
             entity: climate.living
-            grid_options:
-              rows: 3
-              columns: 6
-          - type: thermostat
+            features:
+              - type: target-temperature
+          - type: tile
             entity: climate.study
-            grid_options:
-              rows: 3
-              columns: 6
+            features:
+              - type: target-temperature
           - type: heading
             heading_style: subtitle
             heading: Measurements


### PR DESCRIPTION
## Summary
- Replaces `thermostat` card type with `tile` cards using the `target-temperature` feature on both the climate dashboard and the overview
- More compact and consistent with other tile-based cards in the dashboards

## Test plan
- [x] `just test` passes
- [ ] Pull branch on Pi and verify climate tiles render correctly with target temperature controls