### PR TITLE
Upgrade Zigbee2MQTT from 2.6.3 to 2.10.1

### DIFF
--- a/zigbee2mqtt-amb/docker-compose.yml
+++ b/zigbee2mqtt-amb/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   zigbee2mqtt:
     container_name: zigbee2mqtt
     restart: unless-stopped
-    image: koenkk/zigbee2mqtt:2.6.3
+    image: koenkk/zigbee2mqtt:2.10.1
     volumes:
       - ./zigbee2mqtt-data:/app/data
       - /run/udev:/run/udev:ro


### PR DESCRIPTION
## Summary
- Upgrades Zigbee2MQTT from 2.6.3 to 2.10.1

## Test plan
- [x] Run `docker compose pull && docker compose up -d` in `zigbee2mqtt-amb` on the Pi
- [x] Verify z2m starts and all devices reconnect