### PR TITLE
Fix Hue wall switch spurious toggle after hold-to-dim

### DIFF
--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
@@ -158,12 +158,19 @@ action:
       dim_direction_entity: "{{ dim_dir_left if side == 'left' else dim_dir_right }}"
       brightness_step_pct: !input brightness_step_pct
       direction_timeout: !input direction_timeout
+      # Workaround: Some Hue wall switches occasionally emit left/right_press_release
+      # instead of left/right_hold_release at the end of a hold sequence (firmware timing
+      # bug when the button is released quickly after the last hold tick). Detect this by
+      # checking if the dim direction helper was updated within the last second.
+      dim_state_parts: "{{ states(dim_direction_entity).split('_') }}"
+      last_dim_ts: "{{ dim_state_parts[1] | int(0) if dim_state_parts | length >= 2 else 0 }}"
+      hold_just_occurred: "{{ (now().timestamp() | int - last_dim_ts) <= 1 }}"
 
   - condition: template
     value_template: "{{ active_lights | length > 0 }}"
 
   - choose:
-      - conditions: "{{ command in ['left_press_release', 'right_press_release'] }}"
+      - conditions: "{{ command in ['left_press_release', 'right_press_release'] and not hold_just_occurred }}"
         sequence:
           - action: light.toggle
             target:

--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim_ambiance_color.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim_ambiance_color.yaml
@@ -157,10 +157,18 @@ action:
       dim_direction_entity: !input dim_direction_entity
       brightness_step_pct: !input brightness_step_pct
       direction_timeout: !input direction_timeout
+      # Workaround: Some Hue wall switches occasionally emit left_press_release instead
+      # of left_hold_release at the end of a hold sequence (firmware timing bug that
+      # occurs when the button is released very quickly after the last hold tick).
+      # Detect this by checking if the dim direction helper was updated within the last
+      # second — if so, a hold just happened and the release should be ignored.
+      dim_state_parts: "{{ states(dim_direction_entity).split('_') }}"
+      last_dim_ts: "{{ dim_state_parts[1] | int(0) if dim_state_parts | length >= 2 else 0 }}"
+      hold_just_occurred: "{{ (now().timestamp() | int - last_dim_ts) <= 1 }}"
 
   - choose:
       # --- TURN ON ---
-      - conditions: "{{ command == 'left_press_release' and states(active_lights) != 'on' }}"
+      - conditions: "{{ command == 'left_press_release' and not hold_just_occurred and states(active_lights) != 'on' }}"
         sequence:
           # Turn on via the Zigbee group (single broadcast = all lights respond atomically).
           # The group itself is NOT in the AL config (only the individual sub-groups are),
@@ -183,7 +191,7 @@ action:
               turn_on_lights: true
 
       # --- TURN OFF ---
-      - conditions: "{{ command == 'left_press_release' and states(active_lights) == 'on' }}"
+      - conditions: "{{ command == 'left_press_release' and not hold_just_occurred and states(active_lights) == 'on' }}"
         sequence:
           - action: light.turn_off
             target:


### PR DESCRIPTION
## Summary
- Some Hue wall switches occasionally emit `press_release` instead of `hold_release` at the end of a hold-to-dim sequence (firmware timing bug when the button is released ~100ms after the last hold tick)
- Added a `hold_just_occurred` guard to both `hue_wall_switch_dim` and `hue_wall_switch_dim_ambiance_color` blueprints that checks if the dim direction helper was updated within the last second, ignoring the spurious toggle event

## Test plan
- [ ] Checkout branch on Raspberry Pi and reload automations
- [ ] Test hold-to-dim on Switch Wall Bedroom Olivier — confirm dimming works and no accidental toggle on release
- [ ] Test short-press toggle still works normally