### PR TITLE
Use all-group AL for atomic on/off, remove color sub-group AL

### DIFF
--- a/home-assistant-amb/config/adaptive_lighting.yaml
+++ b/home-assistant-amb/config/adaptive_lighting.yaml
@@ -127,8 +127,8 @@
 # This used to be Duco's bedroom. We are in the process of converting it into a laundry room, but there's still a bed
 # in there and a color light, Olivier decided to sleep in this bed the first night Duco moved to his new room, so
 # keeping the 20:00 sunset time in place for now.
-- name: "laundry-ambiance"
-  lights: ["light.light_group_laundry_ambiance"]
+- name: "laundry"
+  lights: ["light.light_group_laundry"]
   min_brightness: 30
   max_brightness: 35
   min_color_temp: 2200
@@ -137,8 +137,8 @@
   sleep_transition: 5
   interval: 233
 
-- name: "laundry-color"
-  lights: ["light.light_group_laundry_color"]
+- name: "laundry-ambiance"
+  lights: ["light.light_group_laundry_ambiance"]
   min_brightness: 30
   max_brightness: 35
   min_color_temp: 2200
@@ -146,6 +146,16 @@
   max_sunset_time: "20:00:00"
   sleep_transition: 5
   interval: 239
+
+- name: "bedroom-duco"
+  lights: ["light.light_group_bedroom_duco"]
+  min_brightness: 25
+  max_brightness: 30
+  min_color_temp: 2200
+  max_color_temp: 4000
+  max_sunset_time: "20:00:00"
+  sleep_transition: 5
+  interval: 241
 
 - name: "bedroom-duco-ambiance"
   lights: ["light.light_group_bedroom_duco_ambiance"]
@@ -155,20 +165,10 @@
   max_color_temp: 4000
   max_sunset_time: "20:00:00"
   sleep_transition: 5
-  interval: 241
-
-- name: "bedroom-duco-color"
-  lights: ["light.light_group_bedroom_duco_color"]
-  min_brightness: 25
-  max_brightness: 30
-  min_color_temp: 2200
-  max_color_temp: 4000
-  max_sunset_time: "20:00:00"
-  sleep_transition: 5
   interval: 251
 
-- name: "bedroom-olivier-ambiance"
-  lights: ["light.light_group_bedroom_olivier_ambiance"]
+- name: "bedroom-olivier"
+  lights: ["light.light_group_bedroom_olivier"]
   min_brightness: 25
   max_brightness: 30
   min_color_temp: 2200
@@ -177,8 +177,8 @@
   sleep_transition: 5
   interval: 257
 
-- name: "bedroom-olivier-color"
-  lights: ["light.light_group_bedroom_olivier_color"]
+- name: "bedroom-olivier-ambiance"
+  lights: ["light.light_group_bedroom_olivier_ambiance"]
   min_brightness: 25
   max_brightness: 30
   min_color_temp: 2200

--- a/home-assistant-amb/config/automation/light_adaptive_toggle.yaml
+++ b/home-assistant-amb/config/automation/light_adaptive_toggle.yaml
@@ -22,11 +22,11 @@
         - switch.adaptive_lighting_kitchen_middle
         - switch.adaptive_lighting_kitchen_countertop
         - switch.adaptive_lighting_bathroom
+        - switch.adaptive_lighting_laundry
         - switch.adaptive_lighting_laundry_ambiance
-        - switch.adaptive_lighting_laundry_color
+        - switch.adaptive_lighting_bedroom_duco
         - switch.adaptive_lighting_bedroom_duco_ambiance
-        - switch.adaptive_lighting_bedroom_duco_color
+        - switch.adaptive_lighting_bedroom_olivier
         - switch.adaptive_lighting_bedroom_olivier_ambiance
-        - switch.adaptive_lighting_bedroom_olivier_color
         - switch.adaptive_lighting_study
   mode: restart

--- a/home-assistant-amb/config/automation/sleep_mode.yaml
+++ b/home-assistant-amb/config/automation/sleep_mode.yaml
@@ -73,12 +73,12 @@
   action:
     - service: "switch.turn_{{ sleep_mode }}"
       entity_id:
+        - switch.adaptive_lighting_sleep_mode_laundry
         - switch.adaptive_lighting_sleep_mode_laundry_ambiance
-        - switch.adaptive_lighting_sleep_mode_laundry_color
+        - switch.adaptive_lighting_sleep_mode_bedroom_olivier
         - switch.adaptive_lighting_sleep_mode_bedroom_olivier_ambiance
-        - switch.adaptive_lighting_sleep_mode_bedroom_olivier_color
+        - switch.adaptive_lighting_sleep_mode_bedroom_duco
         - switch.adaptive_lighting_sleep_mode_bedroom_duco_ambiance
-        - switch.adaptive_lighting_sleep_mode_bedroom_duco_color
   mode: restart
 
 - alias: "Sleep mode kids: scheduled on"

--- a/home-assistant-amb/config/automation/switch_bedroom_duco.yaml
+++ b/home-assistant-amb/config/automation/switch_bedroom_duco.yaml
@@ -7,10 +7,6 @@
       dim_direction_entity: input_text.dim_direction_switch_wall_bedroom_duco_left
       light_all: light.light_group_bedroom_duco
       light_ambiance: light.light_group_bedroom_duco_ambiance
-      light_color: light.light_group_bedroom_duco_color
       input_boolean_color_blocked: input_boolean.wake_up_lights_kids_cycle_in_progress
-      switch_entities_adapt_brightness:
-        - switch.adaptive_lighting_adapt_brightness_bedroom_duco_ambiance
-        - switch.adaptive_lighting_adapt_brightness_bedroom_duco_color
-      switch_entities_adapt_brightness_ambiance:
-        - switch.adaptive_lighting_adapt_brightness_bedroom_duco_ambiance
+      switch_adapt_brightness_all: switch.adaptive_lighting_adapt_brightness_bedroom_duco
+      switch_adapt_brightness_ambiance: switch.adaptive_lighting_adapt_brightness_bedroom_duco_ambiance

--- a/home-assistant-amb/config/automation/switch_bedroom_olivier.yaml
+++ b/home-assistant-amb/config/automation/switch_bedroom_olivier.yaml
@@ -10,14 +10,14 @@
       light_group_ambiance: light.light_group_bedroom_olivier_ambiance
       light_group_color: light.light_group_bedroom_olivier_color
       switch_entities_adaptive_lighting:
+        - switch.adaptive_lighting_bedroom_olivier
         - switch.adaptive_lighting_bedroom_olivier_ambiance
-        - switch.adaptive_lighting_bedroom_olivier_color
       switch_entities_adaptive_lighting_ambiance:
         - switch.adaptive_lighting_bedroom_olivier_ambiance
-      switch_entities_adapt_brightness: &ref_switch_adapt_brightness
+      switch_entities_adapt_brightness:
+        - switch.adaptive_lighting_adapt_brightness_bedroom_olivier
         - switch.adaptive_lighting_adapt_brightness_bedroom_olivier_ambiance
-        - switch.adaptive_lighting_adapt_brightness_bedroom_olivier_color
-      switch_entities_adapt_brightness_ambiance: &ref_switch_adapt_brightness_ambiance
+      switch_entities_adapt_brightness_ambiance:
         - switch.adaptive_lighting_adapt_brightness_bedroom_olivier_ambiance
       input_boolean_disco: input_boolean.disco_olivier
       input_boolean_color_controls_disabled: input_boolean.wake_up_lights_kids_cycle_in_progress
@@ -31,7 +31,6 @@
       dim_direction_entity: input_text.dim_direction_switch_wall_bedroom_olivier_left
       light_all: light.light_group_bedroom_olivier
       light_ambiance: light.light_group_bedroom_olivier_ambiance
-      light_color: light.light_group_bedroom_olivier_color
       input_boolean_color_blocked: input_boolean.wake_up_lights_kids_cycle_in_progress
-      switch_entities_adapt_brightness: *ref_switch_adapt_brightness
-      switch_entities_adapt_brightness_ambiance: *ref_switch_adapt_brightness_ambiance
+      switch_adapt_brightness_all: switch.adaptive_lighting_adapt_brightness_bedroom_olivier
+      switch_adapt_brightness_ambiance: switch.adaptive_lighting_adapt_brightness_bedroom_olivier_ambiance

--- a/home-assistant-amb/config/automation/switch_laundry.yaml
+++ b/home-assistant-amb/config/automation/switch_laundry.yaml
@@ -12,14 +12,14 @@
       light_group_ambiance: light.light_group_laundry_ambiance
       light_group_color: light.light_group_laundry_color
       switch_entities_adaptive_lighting:
+        - switch.adaptive_lighting_laundry
         - switch.adaptive_lighting_laundry_ambiance
-        - switch.adaptive_lighting_laundry_color
       switch_entities_adaptive_lighting_ambiance:
         - switch.adaptive_lighting_laundry_ambiance
-      switch_entities_adapt_brightness: &ref_switch_adapt_brightness
+      switch_entities_adapt_brightness:
+        - switch.adaptive_lighting_adapt_brightness_laundry
         - switch.adaptive_lighting_adapt_brightness_laundry_ambiance
-        - switch.adaptive_lighting_adapt_brightness_laundry_color
-      switch_entities_adapt_brightness_ambiance: &ref_switch_adapt_brightness_ambiance
+      switch_entities_adapt_brightness_ambiance:
         - switch.adaptive_lighting_adapt_brightness_laundry_ambiance
       input_boolean_disco: input_boolean.disco_laundry
       input_boolean_color_controls_disabled: input_boolean.wake_up_lights_kids_cycle_in_progress
@@ -33,7 +33,6 @@
       dim_direction_entity: input_text.dim_direction_switch_wall_laundry_left
       light_all: light.light_group_laundry
       light_ambiance: light.light_group_laundry_ambiance
-      light_color: light.light_group_laundry_color
       input_boolean_color_blocked: input_boolean.wake_up_lights_kids_cycle_in_progress
-      switch_entities_adapt_brightness: *ref_switch_adapt_brightness
-      switch_entities_adapt_brightness_ambiance: *ref_switch_adapt_brightness_ambiance
+      switch_adapt_brightness_all: switch.adaptive_lighting_adapt_brightness_laundry
+      switch_adapt_brightness_ambiance: switch.adaptive_lighting_adapt_brightness_laundry_ambiance

--- a/home-assistant-amb/config/automation/wake_up_al_coordination.yaml
+++ b/home-assistant-amb/config/automation/wake_up_al_coordination.yaml
@@ -1,0 +1,38 @@
+# Re-enable all-group AL once color lights are turned off after wake-up.
+# The forward direction (all-group OFF, ambiance ON) is handled in wake_up_light_kids.yaml.
+- alias: "Wake up AL: restore all-group"
+  id: wake_up_al_restore_all_group
+  trigger:
+    - platform: state
+      entity_id:
+        - light.light_group_laundry_color
+        - light.light_group_bedroom_olivier_color
+        - light.light_group_bedroom_duco_color
+      from: "on"
+      to: "off"
+    - platform: state
+      entity_id: input_boolean.wake_up_lights_kids_cycle_in_progress
+      from: "on"
+      to: "off"
+  condition:
+    - condition: state
+      entity_id: light.light_group_laundry_color
+      state: "off"
+    - condition: state
+      entity_id: light.light_group_bedroom_olivier_color
+      state: "off"
+    - condition: state
+      entity_id: light.light_group_bedroom_duco_color
+      state: "off"
+  action:
+    - service: switch.turn_off
+      entity_id:
+        - switch.adaptive_lighting_bedroom_olivier_ambiance
+        - switch.adaptive_lighting_bedroom_duco_ambiance
+        - switch.adaptive_lighting_laundry_ambiance
+    - service: switch.turn_on
+      entity_id:
+        - switch.adaptive_lighting_bedroom_olivier
+        - switch.adaptive_lighting_bedroom_duco
+        - switch.adaptive_lighting_laundry
+  mode: restart

--- a/home-assistant-amb/config/automation/wake_up_light_kids.yaml
+++ b/home-assistant-amb/config/automation/wake_up_light_kids.yaml
@@ -12,12 +12,17 @@
     - service: input_boolean.turn_on
       target:
         entity_id: &bool_in_progress input_boolean.wake_up_lights_kids_cycle_in_progress
-    # Without explicitly marking manual control, AL overrides the color:
-    - service: adaptive_lighting.set_manual_control
+    # Switch from all-group AL to ambiance-only AL so color lights are free for wake-up.
+    - service: switch.turn_off
       entity_id:
-        - switch.adaptive_lighting_laundry_color
-        - switch.adaptive_lighting_bedroom_olivier_color
-        - switch.adaptive_lighting_bedroom_duco_color
+        - switch.adaptive_lighting_bedroom_olivier
+        - switch.adaptive_lighting_bedroom_duco
+        - switch.adaptive_lighting_laundry
+    - service: switch.turn_on
+      entity_id:
+        - switch.adaptive_lighting_bedroom_olivier_ambiance
+        - switch.adaptive_lighting_bedroom_duco_ambiance
+        - switch.adaptive_lighting_laundry_ambiance
     - service: light.turn_on
       target:
         entity_id: &lights

--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim_ambiance_color.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim_ambiance_color.yaml
@@ -4,7 +4,7 @@ blueprint:
     Hue Wall Switch for Zigbee2MQTT with hold-to-dim support.
     Left button only. For rooms with separate ambiance and color light groups.
 
-    Short press (release): toggle lights on/off (AL applies automatically via sub-groups).
+    Short press (release): toggle lights on/off via all-group (atomic broadcast).
     Hold: dim light brightness (disables AL adapt_brightness while dimming).
 
     When input_boolean_color_blocked is "on", only ambiance lights are controlled.
@@ -58,7 +58,7 @@ blueprint:
       name: Light group (all lights)
       description: >
         Zigbee group containing all lights in the room.
-        Used during normal operation.
+        Used for on/off toggle and dimming during normal operation.
       selector:
         entity:
           domain: light
@@ -67,16 +67,7 @@ blueprint:
       name: Light group (ambiance only)
       description: >
         Zigbee group containing only ambiance lights.
-        Used when color lights are blocked.
-      selector:
-        entity:
-          domain: light
-          multiple: false
-    light_color:
-      name: Light group (color only)
-      description: >
-        Zigbee group containing only color lights.
-        Used together with light_ambiance for turn-off to ensure correct HA state.
+        Used when color lights are blocked (wake-up mode).
       selector:
         entity:
           domain: light
@@ -92,24 +83,24 @@ blueprint:
           domain: input_boolean
           multiple: false
 
-    switch_entities_adapt_brightness:
-      name: Adapt brightness switches (all)
+    switch_adapt_brightness_all:
+      name: Adapt brightness switch (all-group)
       description: >
-        All adaptive_lighting adapt_brightness switches (ambiance + color).
+        The adapt_brightness switch for the all-group AL instance.
         Turned OFF when dimming, turned ON when toggling on/off.
       selector:
         entity:
           domain: switch
-          multiple: true
-    switch_entities_adapt_brightness_ambiance:
-      name: Adapt brightness switches (ambiance only)
+          multiple: false
+    switch_adapt_brightness_ambiance:
+      name: Adapt brightness switch (ambiance sub-group)
       description: >
-        Ambiance-only adaptive_lighting adapt_brightness switches.
+        The adapt_brightness switch for the ambiance sub-group AL instance.
         Used when color lights are blocked.
       selector:
         entity:
           domain: switch
-          multiple: true
+          multiple: false
 
 mode: parallel
 max: 10
@@ -136,13 +127,12 @@ action:
       command: "{{ trigger.payload }}"
       light_all: !input light_all
       light_ambiance: !input light_ambiance
-      light_color: !input light_color
       input_boolean_color_blocked: !input input_boolean_color_blocked
       color_blocked: "{{ is_state(input_boolean_color_blocked, 'on') }}"
       active_lights: "{{ light_ambiance if color_blocked else light_all }}"
-      switch_adapt_brightness: !input switch_entities_adapt_brightness
-      switch_adapt_brightness_ambiance: !input switch_entities_adapt_brightness_ambiance
-      active_adapt_brightness: "{{ switch_adapt_brightness_ambiance if color_blocked else switch_adapt_brightness }}"
+      switch_adapt_brightness_all: !input switch_adapt_brightness_all
+      switch_adapt_brightness_ambiance: !input switch_adapt_brightness_ambiance
+      active_adapt_brightness: "{{ switch_adapt_brightness_ambiance if color_blocked else switch_adapt_brightness_all }}"
       dim_direction_entity: !input dim_direction_entity
       brightness_step_pct: !input brightness_step_pct
       direction_timeout: !input direction_timeout
@@ -159,10 +149,11 @@ action:
       # --- TURN ON ---
       - conditions: "{{ command == 'left_press_release' and not hold_just_occurred and states(active_lights) != 'on' }}"
         sequence:
-          # Turn on sub-groups directly so AL (which tracks them) applies automatically.
+          # Uses all-group for atomic single-broadcast turn-on. AL tracks this group
+          # directly and applies brightness/color_temp automatically.
           - action: light.turn_on
             target:
-              entity_id: "{{ [light_ambiance, light_color] if not color_blocked else [light_ambiance] }}"
+              entity_id: "{{ active_lights }}"
           # Re-enable adapt_brightness so AL resumes control after any prior manual dimming.
           - action: switch.turn_on
             target:
@@ -171,12 +162,9 @@ action:
       # --- TURN OFF ---
       - conditions: "{{ command == 'left_press_release' and not hold_just_occurred and states(active_lights) == 'on' }}"
         sequence:
-          # Turn off both sub-groups individually rather than the all-group. This ensures
-          # HA state updates correctly for each sub-group (avoids stale "on" state that
-          # causes AL to turn lights back on).
           - action: light.turn_off
             target:
-              entity_id: "{{ [light_ambiance, light_color] if not color_blocked else [light_ambiance] }}"
+              entity_id: "{{ active_lights }}"
           # Re-enable adapt_brightness so AL takes over cleanly on next turn-on.
           - action: switch.turn_on
             target:

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -221,8 +221,8 @@ views:
             grid_options:
               columns: 9
           - type: tile
-            name: Color adapt brightness
-            entity: switch.adaptive_lighting_adapt_brightness_bedroom_olivier_color
+            name: All-group adapt brightness
+            entity: switch.adaptive_lighting_adapt_brightness_bedroom_olivier
             grid_options:
               columns: 9
           - type: tile
@@ -250,8 +250,8 @@ views:
             grid_options:
               columns: 9
           - type: tile
-            name: Color adapt brightness
-            entity: switch.adaptive_lighting_adapt_brightness_laundry_color
+            name: All-group adapt brightness
+            entity: switch.adaptive_lighting_adapt_brightness_laundry
             grid_options:
               columns: 9
           - type: tile
@@ -279,8 +279,8 @@ views:
             grid_options:
               columns: 9
           - type: tile
-            name: Color adapt brightness
-            entity: switch.adaptive_lighting_adapt_brightness_bedroom_duco_color
+            name: All-group adapt brightness
+            entity: switch.adaptive_lighting_adapt_brightness_bedroom_duco
             grid_options:
               columns: 9
 

--- a/home-assistant-amb/config/script.yaml
+++ b/home-assistant-amb/config/script.yaml
@@ -47,11 +47,6 @@ turn_on_light_hall_0_wall_dimmed:
 wake_up_light_kids_set_green:
   alias: "Wake up light kids: Set to green"
   sequence:
-    - service: adaptive_lighting.set_manual_control
-      entity_id:
-        - switch.adaptive_lighting_laundry_color
-        - switch.adaptive_lighting_bedroom_olivier_color
-        - switch.adaptive_lighting_bedroom_duco_color
     - service: light.turn_on
       target:
         entity_id:


### PR DESCRIPTION
## Summary
- Replaces sub-group turn-on/off (2 broadcasts, visible stagger) with all-group turn-on/off (single atomic Zigbee broadcast)
- Adds AL instances for all-groups (bedroom-olivier, bedroom-duco, laundry) — active during normal operation
- Removes color sub-group AL configs entirely (all-group AL covers them normally, wake-up doesn't need them)
- New coordination: wake-up automation disables all-group AL and enables ambiance sub-group AL before setting color; a new `wake_up_al_coordination` automation re-enables all-group AL once color lights are turned off
- Removes `set_manual_control` calls (no longer needed — all-group AL is off during wake-up)
- Simplifies blueprint inputs (single adapt_brightness switch per mode instead of lists)

## Test plan
- [ ] Checkout branch on Raspberry Pi and reload automations
- [ ] Wall switch toggle: lights on/off atomically (no stagger)
- [ ] Verify AL adjusts brightness/color_temp during normal operation
- [ ] Dimming still works correctly
- [ ] Wake-up: orange and green set correctly, green persists until manual off
- [ ] After color lights turned off manually, all-group AL resumes
- [ ] Sleep mode kids toggles correctly
- [ ] Adaptive lighting master toggle works