### PR TITLE
Sync graph line colors with badge colors on climate dashboards

### DIFF
--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -87,7 +87,7 @@ views:
         entity: sensor.climate_study_temperature
         name: Study
         icon: mdi:chair-rolling
-        color: teal
+        color: grey
       - type: entity
         show_name: true
         show_state: true
@@ -111,7 +111,7 @@ views:
         entity: sensor.climate_bedroom_duco_temperature
         icon: mdi:bed
         name: Bedroom Duco
-        color: brown
+        color: teal
       - type: entity
         show_name: true
         show_state: true
@@ -119,7 +119,7 @@ views:
         entity: sensor.climate_attic_temperature
         icon: mdi:home-roof
         name: Attic
-        color: blue
+        color: brown
       - type: entity
         show_name: true
         show_state: true

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -97,7 +97,7 @@ views:
         entity: sensor.climate_study_temperature
         name: Study
         icon: mdi:chair-rolling
-        color: teal
+        color: grey
     sections:
       - type: grid
         column_span: 1


### PR DESCRIPTION
## Summary
- Add explicit `color` properties to history-graph entities on both the climate and overview dashboards so graph lines match badge colors
- Update badge colors for Study (grey), Bedroom Duco (teal), and Attic (brown)

## Test plan
- [ ] Reload dashboards on Pi
- [ ] Verify badge colors match graph line colors on climate/measurements (1-day and 1-week)
- [ ] Verify same on overview dashboard climate section