### PR TITLE
Add HA light groups for combined room toggles

### DIFF
--- a/home-assistant-amb/config/configuration.yaml
+++ b/home-assistant-amb/config/configuration.yaml
@@ -26,6 +26,7 @@ lovelace: !include lovelace.yaml
 logbook: !include logbook.yaml
 script: !include script.yaml
 binary_sensor: !include binary_sensor.yaml
+light: !include light.yaml
 
 # Custom component config files to include
 adaptive_lighting: !include adaptive_lighting.yaml

--- a/home-assistant-amb/config/dashboard/lights.yaml
+++ b/home-assistant-amb/config/dashboard/lights.yaml
@@ -140,6 +140,11 @@ views:
             heading_style: subtitle
             icon: mdi:sofa
           - type: tile
+            name: Spot
+            entity: light.light_group_ha_living_spot
+            features:
+              - type: light-brightness
+          - type: tile
             name: Spot Always
             entity: light.light_group_living_spot_always
             features:
@@ -196,6 +201,12 @@ views:
             heading_style: subtitle
             icon: mdi:bed
           - type: tile
+            name: All
+            entity: light.light_group_ha_bedroom_olivier
+            features_position: bottom
+            features:
+              - type: light-brightness
+          - type: tile
             name: Ambiance
             entity: light.light_group_bedroom_olivier_ambiance
             features_position: bottom
@@ -224,6 +235,12 @@ views:
             heading: Bedroom Duco
             heading_style: subtitle
             icon: mdi:bed
+          - type: tile
+            name: All
+            entity: light.light_group_ha_bedroom_duco
+            features_position: bottom
+            features:
+              - type: light-brightness
           - type: tile
             name: Ambiance
             entity: light.light_group_bedroom_duco_ambiance

--- a/home-assistant-amb/config/light.yaml
+++ b/home-assistant-amb/config/light.yaml
@@ -1,0 +1,22 @@
+# HA-side light groups that combine pairs of Zigbee2MQTT groups for a single
+# on/off toggle per room on the dashboard.
+#
+# Why not just merge these into one z2m group? Adaptive lighting is configured
+# per z2m group so each half can be controlled individually. Merging them in z2m
+# would break that per-group adaptive-lighting control. These HA groups sit on top
+# purely for combined on/off and leave the underlying z2m groups untouched.
+- platform: group
+  name: Light Group HA Living Spot
+  entities:
+    - light.light_group_living_spot_always
+    - light.light_group_living_spot_dark_outside
+- platform: group
+  name: Light Group HA Bedroom Duco
+  entities:
+    - light.light_group_bedroom_duco_ambiance
+    - light.light_group_bedroom_duco_color
+- platform: group
+  name: Light Group HA Bedroom Olivier
+  entities:
+    - light.light_group_bedroom_olivier_ambiance
+    - light.light_group_bedroom_olivier_color


### PR DESCRIPTION
## Summary

- New `light.yaml` defines three HA-side `platform: group` light groups: `Light Group HA Living Spot`, `Light Group HA Bedroom Duco`, `Light Group HA Bedroom Olivier`
- Each wraps two existing Zigbee2MQTT group entities so one button toggles both
- Added as the first tile in each room's section on the Lights → Toggles dashboard

## Why not merge in z2m?

Adaptive lighting is configured per z2m group for individual control. Merging in z2m would break that. These HA groups are purely a dashboard convenience layer.

## Test plan

- [x] Pull branch on Raspberry Pi, restart / reload HA config
- [x] Confirm `light.light_group_ha_living_spot`, `...bedroom_duco`, `...bedroom_olivier` appear in HA
- [x] Toggle each — both member z2m groups should follow
- [x] Lights → Toggles page: "Spot" (Living), "All" (Olivier), "All" (Duco) appear as first entry in each room