### PR TITLE
HA: Improve light manual off in morning

### DIFF
--- a/home-assistant-amb/config/automation/light_manual.yaml
+++ b/home-assistant-amb/config/automation/light_manual.yaml
@@ -7,6 +7,8 @@
     - platform: sun
       event: sunrise
   action:
+    - alias: "Wait until it is at least 08:00 to prevent turing off kids alarms"
+      wait_template: "{{ now().strftime('%H:%M:%S') >= '08:00:00' }}"
     - alias: "Wait until it is sufficiently light outside"
       wait_for_trigger:
         platform: state
@@ -19,7 +21,25 @@
         transition: 30
       target:
         entity_id:
+          # Individual lights:
           - light.light_bedroom_jc_bed_c
           - light.light_bedroom_jc_bed_j
+          # Zigbee groups from here on, sprinkle in some delays to not do too many broadcasts at the same time:
           - light.light_group_bedroom_olivier_ambiance
           - light.light_group_bedroom_olivier_color
+    - delay: "00:00:02"
+    - service: light.turn_off
+      data:
+        transition: 28
+      target:
+        entity_id:
+          - light.light_group_bedroom_duco_ambiance
+          - light.light_group_bedroom_duco_color
+    - delay: "00:00:02"
+    - service: light.turn_off
+      data:
+        transition: 26
+      target:
+        entity_id:
+          - light.light_group_laundry
+

--- a/home-assistant-amb/config/automation/light_manual.yaml
+++ b/home-assistant-amb/config/automation/light_manual.yaml
@@ -42,4 +42,3 @@
       target:
         entity_id:
           - light.light_group_laundry
-


### PR DESCRIPTION
- Increase coverage: Duco and Laundry missing
- Wait until at least 08:00 for summer months - otherwise, may turn off wake up lights before kids are awake. 08:00 seems safe, they usually don't even come close.