### PR TITLE
teslamate: upgrade 2.2.0 → 4.x + fix Owner API 403 (PR #5406 build)

### DIFF
--- a/teslamate/docker-compose.yml
+++ b/teslamate/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   teslamate:
-    image: teslamate/teslamate:2.2.0
+    image: teslamate/teslamate:4.0.0
     restart: always
     depends_on:
       - database
@@ -34,7 +34,7 @@ services:
       - teslamate-db:/var/lib/postgresql
 
   grafana:
-    image: teslamate/grafana:2.2.0
+    image: teslamate/grafana:4.0.0
     restart: always
     environment:
       - DATABASE_USER=${TM_DB_USER}

--- a/teslamate/docker-compose.yml
+++ b/teslamate/docker-compose.yml
@@ -1,6 +1,12 @@
 services:
   teslamate:
-    image: teslamate/teslamate:4.0.0
+    # TEMPORARY: pinned to the PR #5406 CI build, not a stable release.
+    # v4.0.0 does NOT fix the Tesla Owner API 403 errors (issue #5399): Tesla began
+    # fingerprint-blocking third-party Owner API clients. Earlier workarounds (TLS 1.3
+    # only, PR #5390; custom User-Agent) all failed. PR #5406 enables HTTP/2 + TLS 1.3
+    # for the Tesla auth host to mimic an accepted client fingerprint.
+    # Revert to a stable tagged release (teslamate/teslamate:<version>) once a fix ships.
+    image: ghcr.io/teslamate-org/teslamate:pr-5406
     restart: always
     depends_on:
       - database

--- a/teslamate/get-token.py
+++ b/teslamate/get-token.py
@@ -1,53 +1,63 @@
-import os
 import hashlib
 import base64
+import os
+import sys
+from urllib.parse import urlparse, parse_qs
 import requests
 
 code_verifier = base64.urlsafe_b64encode(os.urandom(86)).rstrip(b"=")
 code_challenge = base64.urlsafe_b64encode(hashlib.sha256(code_verifier).digest()).rstrip(b"=").decode("utf-8")
 state = base64.urlsafe_b64encode(os.urandom(16)).rstrip(b"=").decode("utf-8")
 
-headers = {
-    "User-Agent": "",
-    "x-tesla-user-agent": "",
-    "X-Requested-With": "com.teslamotors.tesla",
-}
+redirect_uri = "tesla://auth/callback"
 
-
-print("Open link in browser and sign in:")
+print("Open this URL in a browser and sign in:")
 print(
-    "https://auth.tesla.com/oauth2/v3/authorize?audience=https%3A%2F%2Fownership.tesla.com%2F"
-    f"&client_id=ownerapi&code_challenge={code_challenge}"
+    "https://auth.tesla.com/oauth2/v3/authorize"
+    f"?client_id=ownerapi"
+    f"&code_challenge={code_challenge}"
     "&code_challenge_method=S256"
     "&locale=en-US"
     "&prompt=login"
-    "&redirect_uri=https%3A%2F%2Fauth.tesla.com%2Fvoid%2Fcallback"
-    "&response_type=code&scope=openid+email+offline_access"
+    f"&redirect_uri=tesla%3A%2F%2Fauth%2Fcallback"
+    "&response_type=code"
+    "&scope=openid+email+offline_access"
     f"&state={state}"
 )
+print()
+print("After signing in, the browser will show an error page for 'tesla://'.")
+print("Copy the full URL from the address bar (starts with 'tesla://') and paste it here:")
+callback_url = input("URL: ").strip()
 
-print("After authentication, you'll get a code in the URL. Paste it here:")
-code = input("Code: ")
+parsed = urlparse(callback_url)
+params = parse_qs(parsed.query)
 
-data = {
-    "grant_type": "authorization_code",
-    "client_id": "ownerapi",
-    "code_verifier": code_verifier.decode("utf-8"),
-    "code": code,
-    "redirect_uri": "https://auth.tesla.com/void/callback",
-}
+returned_state = params.get("state", [None])[0]
+if returned_state != state:
+    print("ERROR: CSRF state mismatch. Do not reuse the auth URL — run the script again.")
+    sys.exit(1)
 
-session = requests.Session()
-response = session.post("https://auth.tesla.com/oauth2/v3/token", headers=headers, json=data)
+code = params.get("code", [None])[0]
+if not code:
+    print("ERROR: No 'code' found in callback URL.")
+    sys.exit(1)
+
+response = requests.post(
+    "https://auth.tesla.com/oauth2/v3/token",
+    json={
+        "grant_type": "authorization_code",
+        "client_id": "ownerapi",
+        "code_verifier": code_verifier.decode("utf-8"),
+        "code": code,
+        "redirect_uri": redirect_uri,
+    },
+)
 response.raise_for_status()
 
-print("")
-print("***** Your access_token is *****")
-print("")
-access_token = response.json()["access_token"]
-print(access_token)
-print("")
-print("***** Your refresh_token is *****")
-print("")
-refresh_token = response.json()["refresh_token"]
-print(refresh_token)
+data = response.json()
+print()
+print("***** Access Token *****")
+print(data["access_token"])
+print()
+print("***** Refresh Token *****")
+print(data["refresh_token"])

--- a/teslamate/get-token.py
+++ b/teslamate/get-token.py
@@ -25,8 +25,15 @@ print(
     f"&state={state}"
 )
 print()
-print("After signing in, the browser will show an error page for 'tesla://'.")
-print("Copy the full URL from the address bar (starts with 'tesla://') and paste it here:")
+print("After signing in, Tesla redirects to tesla://auth/callback?code=...")
+print("The browser can't open tesla:// links, so it will show 'Verified Successfully / Loading...' and hang.")
+print("To get the URL:")
+print("  1. Open DevTools (Cmd+Option+I) BEFORE clicking the link above")
+print("  2. Go to Network tab, enable 'Preserve log'")
+print("  3. Sign in — after 'Verified Successfully', look for a failed request starting with 'tesla://'")
+print("  4. Right-click it → Copy → Copy link address")
+print()
+print("Paste the full tesla://auth/callback?code=...&state=... URL here:")
 callback_url = input("URL: ").strip()
 
 parsed = urlparse(callback_url)


### PR DESCRIPTION
## Summary

TeslaMate `2.2.0` was throwing `403 Forbidden` errors against the Tesla Owner API. Root cause: **Tesla now requires HTTP/2 + TLS 1.3 on the Owner API auth host** (see teslamate-org/teslamate#5399). The older HTTP client (HTTP/1.1 / TLS 1.2) gets rejected even with a valid token.

This PR:
- Upgrades from `2.2.0` to a `4.x` base — a significant jump (across the 3.0.0 license change and 4.0.0's ARMv7 drop). DB migrations run automatically on container start.
- Pins the `teslamate` image to the community CI build **`ghcr.io/teslamate-org/teslamate:pr-5406`** (branched off `main`, i.e. `4.1.0-dev`), which enables **HTTP/2 + TLS 1.3** for the Tesla auth host. This is what actually resolves the 403.
- Bumps **grafana** `2.2.0` → `4.0.0` (stable tag; grafana is unaffected by the 403).
- Fixes `get-token.py` for Tesla's current auth flow (removed dead `audience` param that caused "Invalid audience"; uses `tesla://auth/callback` and parses the full callback URL; CSRF state check; clearer DevTools instructions).

No changes to Postgres (already `postgres:18-trixie`), MQTT, env vars, networks, or ports.

## What changed on Tesla's side

The OAuth **token** is still accepted (`POST /token → 200`), but the subsequent Owner API call (`GET /api/1/products`) returned `403`. The discriminator is at the transport layer — Tesla now requires HTTP/2 + TLS 1.3, which is what their own apps use. Matching that protocol stack passes.

Note: the 403 body points to the Fleet API (`"see https://developer.tesla.com/docs/fleet-api"`), so this may be a deliberate step toward deprecating third-party Owner API access rather than just security hardening — intent is unconfirmed. Either way, Tesla can change the requirements again at any time.

## Why not just v4.0.0 / earlier fixes

v4.0.0's changelog claims it fixes the 403, but it does **not** — confirmed widespread in issue #5399. Earlier workarounds (TLS 1.3 only, PR #5390; custom User-Agent) all failed. PR #5406 (HTTP/2 + TLS 1.3 together) is the one that works.

⚠️ **Temporary**: `pr-5406` is an unstable, moving CI tag on a dev branch. Revert to a stable tagged release (`teslamate/teslamate:<version>`) once an official fix ships.

## Status

✅ **Verified working on the Pi** — TeslaMate refreshes tokens and lists vehicles again, no 403 errors.

## Deployment (on the Pi, in `teslamate/`)

```bash
git checkout upgrade-teslamate-4.0.0 && git pull
docker compose pull   # re-fetches the moving pr-5406 build
docker compose up -d
docker compose logs -f teslamate
```

If 403s ever return (Tesla changes requirements again), the fallback is migrating to the Tesla Fleet API.