### PR TITLE
Add local Duux fan control via duux-emqx + duux_fan_local integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ This repository contains Docker-based services for a Raspberry Pi smart home set
 - **zigbee2mqtt-amb**: Zigbee device integration via MQTT
 - **teslamate**: Tesla vehicle tracking
 - **samba**: File sharing
+- **duux-emqx**: Dedicated EMQX broker for Duux fan local control (LAN-exposed TLS on port 443)
 
 ## Common Commands
 
@@ -24,8 +25,9 @@ just build              # Build Docker image with custom components
 just test               # Validate Home Assistant configuration (requires Docker)
 ```
 
-The build process creates a custom Docker image based on `ghcr.io/home-assistant/home-assistant:2026.5.2` with one baked-in custom component:
+The build process creates a custom Docker image based on `ghcr.io/home-assistant/home-assistant:2026.5.2` with baked-in custom components:
 - **adaptive-lighting**: Dynamic light color/brightness adjustment
+- **duux_fan_local**: Local control of Duux fans via the `duux-emqx/` broker
 
 ### Pre-commit Hooks
 

--- a/duux-emqx/.gitignore
+++ b/duux-emqx/.gitignore
@@ -1,0 +1,2 @@
+certs/
+auth-bootstrap.json

--- a/duux-emqx/README.md
+++ b/duux-emqx/README.md
@@ -1,0 +1,142 @@
+# duux-emqx
+
+Dedicated EMQX broker for the two **Duux Whisper Flex 2** fans. Kept isolated from the internal `mqtt/` mosquitto broker by design — the fans are LAN Wi-Fi clients, so this broker is LAN-exposed (port 443), while the internal bus is loopback-only.
+
+The `duux_fan_local` Home Assistant custom integration is baked into the HA image (see `home-assistant-amb/docker/Dockerfile`). It connects with its own paho-mqtt client (always TLS, cert not verified) directly to this broker — it does **not** use HA's core MQTT integration.
+
+## How the hijack works
+
+1. The fans talk to `collector3.cloudgarden.nl:443` over MQTT-TLS.
+2. A UniFi DNS rewrite points that hostname at the Pi's LAN IP.
+3. EMQX listens on `0.0.0.0:8883`, published on host port `443`.
+4. The fans connect to EMQX instead of the cloud.
+
+## Secrets (not in git)
+
+| File | Contents |
+|---|---|
+| `certs/collector3.cloudgarden.nl.key` | TLS private key |
+| `certs/collector3.cloudgarden.nl.crt` | Self-signed TLS cert |
+| `auth-bootstrap.json` | Real credentials (copy from `.example`, fill in) |
+
+## One-time setup
+
+### 1. Generate the self-signed certificate
+
+Run from the `duux-emqx/` directory on the Pi:
+
+```bash
+mkdir -p certs
+openssl req -x509 -nodes -newkey rsa:2048 \
+  -keyout certs/collector3.cloudgarden.nl.key \
+  -out    certs/collector3.cloudgarden.nl.crt \
+  -days 3650 \
+  -subj "/CN=collector3.cloudgarden.nl" \
+  -addext "subjectAltName=DNS:collector3.cloudgarden.nl"
+```
+
+The cert CN/SAN must match `collector3.cloudgarden.nl` — the fan firmware verifies the hostname (or at minimum paho does on the HA side; either way it costs nothing to match).
+
+### 2. Capture fan credentials (socat MITM)
+
+The fans embed a firmware username (`USER_@<MAC>`) and a 64-character password. To get them, intercept the first TLS connection.
+
+Do this **per fan**, **before** bringing EMQX up:
+
+```bash
+apt-get install -y socat
+
+# Run on the Pi (as root, since :443 is privileged):
+socat OPENSSL-LISTEN:443,reuseaddr,fork,cert=certs/collector3.cloudgarden.nl.crt,key=certs/collector3.cloudgarden.nl.key,verify=0 STDOUT 2>&1 | tee duux_capture_fan1.log
+```
+
+Then:
+1. Set the UniFi DNS rewrite: `collector3.cloudgarden.nl → <PI_LAN_IP>` (see below).
+2. Reboot the fan: unplug → remove battery if applicable → wait ~1 s → reinsert → power on.
+3. Watch the log. The CONNECT packet contains the username and password in plain text.
+4. Stop socat (`Ctrl-C`).
+5. Repeat for the second fan (rename the log file).
+
+Example capture output (excerpt):
+```
+...CONNECT...USER_@aabbccddeeff...64characterpasswordhere...
+```
+
+### 3. Fill in credentials
+
+```bash
+cp auth-bootstrap.json.example auth-bootstrap.json
+# Edit auth-bootstrap.json: replace ha_reader password, and both USER_@<MAC> entries
+# Edit acl.conf: replace USER_@<MAC1> and USER_@<MAC2> with the real usernames
+```
+
+Also choose a strong password for `ha_reader` — this is what you'll enter in the HA integration config flow.
+
+### 4. UniFi DNS rewrite
+
+Console → Settings → Policy Engine → DNS → Create a new **Host (A)** entry:
+
+| Hostname | IP |
+|---|---|
+| `collector3.cloudgarden.nl` | `<PI_LAN_IP>` |
+
+### 5. Deploy EMQX
+
+```bash
+cd duux-emqx
+docker compose up -d
+```
+
+Verify the TLS listener bound:
+```bash
+docker logs duux-emqx | grep "SSL listener"
+```
+
+Dashboard (read-only check, via SSH tunnel from your laptop):
+```bash
+ssh -L 18083:127.0.0.1:18083 pi@<PI_LAN_IP>
+# then open http://localhost:18083 (default creds: admin / public, change on first login)
+```
+
+### 6. Reboot both fans
+
+Unplug each fan, wait ~1 s, power back on. After ~30 s they should appear as connected clients in the EMQX dashboard under "Clients".
+
+### 7. Deploy + rebuild Home Assistant
+
+The `duux_fan_local` component is baked into the image:
+
+```bash
+cd home-assistant-amb
+docker compose up -d --build
+```
+
+### 8. Add the integration (×2, once per fan)
+
+In HA: **Settings → Devices & Services → Add Integration → "Duux Fan Local"**
+
+| Field | Value |
+|---|---|
+| MQTT Host | `collector3.cloudgarden.nl` |
+| MQTT Port | `443` |
+| Username | `ha_reader` |
+| Password | `<ha_reader password from auth-bootstrap.json>` |
+| Model | Whisper Flex 2 |
+| Name | e.g. `Fan Office` / `Fan Bedroom` |
+| Device ID | Fan's MAC address, **lowercased**, e.g. `aabbccddeeff` |
+
+Repeat for the second fan with its own name and MAC.
+
+## Verification
+
+- Both fans appear as connected EMQX clients in the dashboard.
+- Each fan creates a device in HA with fan + sensor entities.
+- Toggling power / speed in HA actuates the physical fan.
+- Manual state changes on the fan (e.g. via its remote) reflect back in HA within a few seconds.
+
+## Port summary
+
+| Port | Binding | Purpose |
+|---|---|---|
+| `443` | `0.0.0.0:443` | MQTT-TLS — fans connect here |
+| `18083` | `127.0.0.1:18083` | EMQX dashboard (loopback-only) |

--- a/duux-emqx/README.md
+++ b/duux-emqx/README.md
@@ -39,7 +39,7 @@ The cert CN/SAN must match `collector3.cloudgarden.nl` — the fan firmware veri
 
 ### 2. Capture fan credentials (socat MITM)
 
-The fans embed a firmware username (`USER_@<MAC>`) and a 64-character password. To get them, intercept the first TLS connection.
+The fans use their **MAC address** (lowercase, colon-separated, e.g. `aa:bb:cc:dd:ee:ff`) as the MQTT username, and a 64-character password. To get them, intercept the first TLS connection.
 
 Do this **per fan**, **before** bringing EMQX up:
 
@@ -59,18 +59,28 @@ Then:
 
 Example capture output (excerpt):
 ```
-...CONNECT...USER_@aabbccddeeff...64characterpasswordhere...
+...CONNECT...aa:bb:cc:dd:ee:ff...64characterpasswordhere...
 ```
+The topic prefix in the published messages (`sensor/<mac>/...`) confirms the username/device id.
 
 ### 3. Fill in credentials
 
 ```bash
 cp auth-bootstrap.json.example auth-bootstrap.json
-# Edit auth-bootstrap.json: replace ha_reader password, and both USER_@<MAC> entries
-# Edit acl.conf: replace USER_@<MAC1> and USER_@<MAC2> with the real usernames
+# Edit auth-bootstrap.json: set ha_reader password, and one entry per fan MAC
+# Edit acl.conf: replace the <MAC> placeholders with the real fan MAC(s)
 ```
 
+`auth-bootstrap.json` uses EMQX's bootstrap format — the key is **`user_id`** (not `username`),
+and `bootstrap_type = plain` (set in `emqx.conf`) means passwords are stored as written.
+
 Also choose a strong password for `ha_reader` — this is what you'll enter in the HA integration config flow.
+
+> **Important:** the bootstrap file is only read on the **first** start of a fresh data
+> volume. If EMQX already ran once, the built-in DB is non-empty and the file is ignored.
+> To re-bootstrap: `docker compose down -v && docker compose up -d` (the `-v` wipes the
+> EMQX data volume). Alternatively add users live via the dashboard
+> (**Access Control → Authentication → Built-in Database → User Management → + Add**).
 
 ### 4. UniFi DNS rewrite
 

--- a/duux-emqx/README.md
+++ b/duux-emqx/README.md
@@ -132,8 +132,12 @@ In HA: **Settings → Devices & Services → Add Integration → "Duux Fan Local
 | Username | `ha` |
 | Password | `<ha password from auth-bootstrap.json>` |
 | Model | Whisper Flex 2 |
-| Name | e.g. `Fan Office` / `Fan Bedroom` |
-| Device ID | Fan's MAC address, **lowercased**, e.g. `aabbccddeeff` |
+| Name | e.g. `Bedroom JC` / `Study` |
+| Device ID | Fan's MAC address, lowercase **colon-separated**, e.g. `aa:bb:cc:dd:ee:ff` |
+
+The Device ID must match the MAC in the fan's MQTT topic (`sensor/<mac>/in`) exactly —
+colons included. Using a colonless form subscribes to the wrong topic and the entity
+never updates.
 
 Repeat for the second fan with its own name and MAC.
 

--- a/duux-emqx/README.md
+++ b/duux-emqx/README.md
@@ -67,14 +67,14 @@ The topic prefix in the published messages (`sensor/<mac>/...`) confirms the use
 
 ```bash
 cp auth-bootstrap.json.example auth-bootstrap.json
-# Edit auth-bootstrap.json: set ha_reader password, and one entry per fan MAC
+# Edit auth-bootstrap.json: set ha password, and one entry per fan MAC
 # Edit acl.conf: replace the <MAC> placeholders with the real fan MAC(s)
 ```
 
 `auth-bootstrap.json` uses EMQX's bootstrap format — the key is **`user_id`** (not `username`),
 and `bootstrap_type = plain` (set in `emqx.conf`) means passwords are stored as written.
 
-Also choose a strong password for `ha_reader` — this is what you'll enter in the HA integration config flow.
+Also choose a strong password for `ha` — this is what you'll enter in the HA integration config flow.
 
 > **Important:** the bootstrap file is only read on the **first** start of a fresh data
 > volume. If EMQX already ran once, the built-in DB is non-empty and the file is ignored.
@@ -129,8 +129,8 @@ In HA: **Settings → Devices & Services → Add Integration → "Duux Fan Local
 |---|---|
 | MQTT Host | `collector3.cloudgarden.nl` |
 | MQTT Port | `443` |
-| Username | `ha_reader` |
-| Password | `<ha_reader password from auth-bootstrap.json>` |
+| Username | `ha` |
+| Password | `<ha password from auth-bootstrap.json>` |
 | Model | Whisper Flex 2 |
 | Name | e.g. `Fan Office` / `Fan Bedroom` |
 | Device ID | Fan's MAC address, **lowercased**, e.g. `aabbccddeeff` |

--- a/duux-emqx/acl.conf
+++ b/duux-emqx/acl.conf
@@ -9,7 +9,7 @@
 
 {allow, {user, "ha_reader"}, subscribe, ["sensor/#"]}.
 
-{allow, {user, "28:05:a5:42:fa:cc"}, publish,   ["sensor/28:05:a5:42:fa:cc"]}.
-{allow, {user, "28:05:a5:42:fa:cc"}, subscribe, ["sensor/28:05:a5:42:fa:cc"]}.
+{allow, {user, "28:05:a5:42:fa:cc"}, publish,   ["sensor/28:05:a5:42:fa:cc/#"]}.
+{allow, {user, "28:05:a5:42:fa:cc"}, subscribe, ["sensor/28:05:a5:42:fa:cc/#"]}.
 
 {deny, all}.

--- a/duux-emqx/acl.conf
+++ b/duux-emqx/acl.conf
@@ -1,0 +1,18 @@
+%% ACL rules for the Duux fan broker.
+%%
+%% Fan users (USER_@<MAC>) may publish + subscribe their own sensor topics.
+%% ha_reader subscribes all sensor topics (read-only for Home Assistant).
+%% All other traffic is denied (broker-level default = deny).
+%%
+%% Replace USER_@<MAC1> and USER_@<MAC2> with the actual usernames captured
+%% from the socat credential-capture step (see README.md).
+
+{allow, {user, "ha_reader"}, subscribe, ["sensor/#"]}.
+
+{allow, {user, "USER_@<MAC1>"}, publish,   ["sensor/#"]}.
+{allow, {user, "USER_@<MAC1>"}, subscribe, ["sensor/#"]}.
+
+{allow, {user, "USER_@<MAC2>"}, publish,   ["sensor/#"]}.
+{allow, {user, "USER_@<MAC2>"}, subscribe, ["sensor/#"]}.
+
+{deny, all}.

--- a/duux-emqx/acl.conf
+++ b/duux-emqx/acl.conf
@@ -10,9 +10,11 @@
 {allow, {user, "ha"}, subscribe, ["sensor/#"]}.
 {allow, {user, "ha"}, publish,   ["sensor/#"]}.
 
+%% Bedroom JC
 {allow, {user, "28:05:a5:42:fa:cc"}, publish,   ["sensor/28:05:a5:42:fa:cc/#"]}.
 {allow, {user, "28:05:a5:42:fa:cc"}, subscribe, ["sensor/28:05:a5:42:fa:cc/#"]}.
 
+%% Study
 {allow, {user, "e0:8c:fe:49:a4:54"}, publish,   ["sensor/e0:8c:fe:49:a4:54/#"]}.
 {allow, {user, "e0:8c:fe:49:a4:54"}, subscribe, ["sensor/e0:8c:fe:49:a4:54/#"]}.
 

--- a/duux-emqx/acl.conf
+++ b/duux-emqx/acl.conf
@@ -13,4 +13,7 @@
 {allow, {user, "28:05:a5:42:fa:cc"}, publish,   ["sensor/28:05:a5:42:fa:cc/#"]}.
 {allow, {user, "28:05:a5:42:fa:cc"}, subscribe, ["sensor/28:05:a5:42:fa:cc/#"]}.
 
+{allow, {user, "e0:8c:fe:49:a4:54"}, publish,   ["sensor/e0:8c:fe:49:a4:54/#"]}.
+{allow, {user, "e0:8c:fe:49:a4:54"}, subscribe, ["sensor/e0:8c:fe:49:a4:54/#"]}.
+
 {deny, all}.

--- a/duux-emqx/acl.conf
+++ b/duux-emqx/acl.conf
@@ -1,13 +1,14 @@
 %% ACL rules for the Duux fan broker.
 %%
-%% Fan users (USER_@<MAC>) may publish + subscribe their own sensor topics.
-%% ha_reader subscribes all sensor topics (read-only for Home Assistant).
+%% Fan users (<MAC>) may publish + subscribe their own sensor topics.
+%% ha may subscribe (read state) and publish (send commands) all sensor topics.
 %% All other traffic is denied (broker-level default = deny).
 %%
-%% Replace USER_@<MAC1> and USER_@<MAC2> with the actual usernames captured
+%% Replace the <MAC> placeholders with the actual fan usernames captured
 %% from the socat credential-capture step (see README.md).
 
-{allow, {user, "ha_reader"}, subscribe, ["sensor/#"]}.
+{allow, {user, "ha"}, subscribe, ["sensor/#"]}.
+{allow, {user, "ha"}, publish,   ["sensor/#"]}.
 
 {allow, {user, "28:05:a5:42:fa:cc"}, publish,   ["sensor/28:05:a5:42:fa:cc/#"]}.
 {allow, {user, "28:05:a5:42:fa:cc"}, subscribe, ["sensor/28:05:a5:42:fa:cc/#"]}.

--- a/duux-emqx/acl.conf
+++ b/duux-emqx/acl.conf
@@ -9,10 +9,7 @@
 
 {allow, {user, "ha_reader"}, subscribe, ["sensor/#"]}.
 
-{allow, {user, "USER_@<MAC1>"}, publish,   ["sensor/#"]}.
-{allow, {user, "USER_@<MAC1>"}, subscribe, ["sensor/#"]}.
-
-{allow, {user, "USER_@<MAC2>"}, publish,   ["sensor/#"]}.
-{allow, {user, "USER_@<MAC2>"}, subscribe, ["sensor/#"]}.
+{allow, {user, "28:05:a5:42:fa:cc"}, publish,   ["sensor/28:05:a5:42:fa:cc"]}.
+{allow, {user, "28:05:a5:42:fa:cc"}, subscribe, ["sensor/28:05:a5:42:fa:cc"]}.
 
 {deny, all}.

--- a/duux-emqx/auth-bootstrap.json.example
+++ b/duux-emqx/auth-bootstrap.json.example
@@ -1,14 +1,14 @@
 [
   {
-    "username": "ha_reader",
+    "user_id": "ha_reader",
     "password": "<CHOOSE_A_STRONG_PASSWORD>"
   },
   {
-    "username": "USER_@<MAC1>",
+    "user_id": "<FAN1_MAC>",
     "password": "<64_CHAR_PASSWORD_FROM_SOCAT_CAPTURE_FAN1>"
   },
   {
-    "username": "USER_@<MAC2>",
+    "user_id": "<FAN2_MAC>",
     "password": "<64_CHAR_PASSWORD_FROM_SOCAT_CAPTURE_FAN2>"
   }
 ]

--- a/duux-emqx/auth-bootstrap.json.example
+++ b/duux-emqx/auth-bootstrap.json.example
@@ -1,6 +1,6 @@
 [
   {
-    "user_id": "ha_reader",
+    "user_id": "ha",
     "password": "<CHOOSE_A_STRONG_PASSWORD>"
   },
   {

--- a/duux-emqx/auth-bootstrap.json.example
+++ b/duux-emqx/auth-bootstrap.json.example
@@ -1,0 +1,14 @@
+[
+  {
+    "username": "ha_reader",
+    "password": "<CHOOSE_A_STRONG_PASSWORD>"
+  },
+  {
+    "username": "USER_@<MAC1>",
+    "password": "<64_CHAR_PASSWORD_FROM_SOCAT_CAPTURE_FAN1>"
+  },
+  {
+    "username": "USER_@<MAC2>",
+    "password": "<64_CHAR_PASSWORD_FROM_SOCAT_CAPTURE_FAN2>"
+  }
+]

--- a/duux-emqx/docker-compose.yml
+++ b/duux-emqx/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  duux-emqx:
+    image: emqx/emqx:5.10.4
+    container_name: duux-emqx
+    restart: unless-stopped
+    ports:
+      # LAN MQTT-TLS: fans connect here (DNS-hijacked from collector3.cloudgarden.nl:443)
+      - "443:8883"
+      # EMQX dashboard: loopback-only, access via SSH tunnel
+      - "127.0.0.1:18083:18083"
+    volumes:
+      - ./certs:/opt/emqx/certs:ro
+      - ./emqx.conf:/opt/emqx/etc/emqx.conf:ro
+      - ./acl.conf:/opt/emqx/etc/acl.conf:ro
+      - ./auth-bootstrap.json:/opt/emqx/etc/auth-bootstrap.json:ro
+      - duux-emqx-data:/opt/emqx/data
+
+volumes:
+  duux-emqx-data:

--- a/duux-emqx/emqx.conf
+++ b/duux-emqx/emqx.conf
@@ -14,6 +14,13 @@ log {
   }
 }
 
+## Dashboard: explicit HTTP listener (EMQX 5.x defaults to HTTPS)
+dashboard {
+  listeners.http {
+    bind = 18083
+  }
+}
+
 ## Disable the default plaintext listener — fans only speak TLS
 listeners.tcp.default {
   enable = false

--- a/duux-emqx/emqx.conf
+++ b/duux-emqx/emqx.conf
@@ -1,0 +1,56 @@
+## EMQX configuration for Duux fan local broker
+## Fans connect via TLS on port 443 (mapped from host 443 → container 8883).
+## Cert CN/SAN = collector3.cloudgarden.nl (matches the DNS-hijacked hostname).
+
+node {
+  name = "emqx@127.0.0.1"
+  cookie = "duux-emqx-cookie"
+  data_dir = "/opt/emqx/data"
+}
+
+log {
+  console {
+    level = info
+  }
+}
+
+## Disable the default plaintext listener — fans only speak TLS
+listeners.tcp.default {
+  enable = false
+}
+
+## TLS listener on 8883 (host publishes as :443)
+listeners.ssl.default {
+  bind = "0.0.0.0:8883"
+  ssl_options {
+    keyfile  = "/opt/emqx/certs/collector3.cloudgarden.nl.key"
+    certfile = "/opt/emqx/certs/collector3.cloudgarden.nl.crt"
+    cacertfile = "/opt/emqx/certs/collector3.cloudgarden.nl.crt"
+    verify = verify_none
+  }
+}
+
+## Built-in database authentication (users bootstrapped from auth-bootstrap.json)
+authentication = [
+  {
+    backend = built_in_database
+    mechanism = password_based
+    password_hash_algorithm {
+      name = bcrypt
+    }
+    bootstrap_file = "/opt/emqx/etc/auth-bootstrap.json"
+    bootstrap_type = plain
+  }
+]
+
+## File-based authorisation (acl.conf)
+authorization {
+  no_match = deny
+  deny_action = disconnect
+  sources = [
+    {
+      type = file
+      path = "/opt/emqx/etc/acl.conf"
+    }
+  ]
+}

--- a/home-assistant-amb/docker/Dockerfile
+++ b/home-assistant-amb/docker/Dockerfile
@@ -14,3 +14,11 @@ RUN cd /tmp \
 	&& unzip adaptive-lighting.zip \
 	&& mv adaptive-lighting-${ADAPTIVE_LIGHTING_VERSION}/custom_components/adaptive_lighting ${CUSTOM_COMPONENTS_DIR} \
 	&& rm -rf /tmp/*
+
+# Add Duux Fan Local (local control of Duux fans via MQTT-TLS broker hijack)
+ARG DUUX_FAN_LOCAL_VERSION=2.0.1
+RUN cd /tmp \
+    && wget -O duux-fan-local.zip https://github.com/LouisR-git/duux-fan-local/archive/refs/tags/${DUUX_FAN_LOCAL_VERSION}.zip \
+    && unzip duux-fan-local.zip \
+    && mv duux-fan-local-${DUUX_FAN_LOCAL_VERSION}/custom_components/duux_fan_local ${CUSTOM_COMPONENTS_DIR} \
+    && rm -rf /tmp/*


### PR DESCRIPTION
## Summary

- **`duux-emqx/`**: new isolated EMQX 5.10.4 broker that intercepts the fans' cloud MQTT connection (`collector3.cloudgarden.nl:443`). LAN-exposed TLS on `:443`, dashboard loopback-only on `:18083`. Authenticated with built-in DB + ACL. Certs and real `auth-bootstrap.json` are gitignored; an `.example` template is committed.
- **`home-assistant-amb/docker/Dockerfile`**: bake `duux_fan_local` 2.0.1 alongside `adaptive-lighting` using the same download-and-move pattern.
- **`CLAUDE.md`**: add `duux-emqx` to services list and note the new custom component.

## Architecture note

The `duux_fan_local` integration uses its own paho-mqtt client (always TLS, `cert_reqs=CERT_NONE`) — it does NOT use HA's core MQTT integration. The Duux broker is therefore kept entirely separate from the loopback-only `mqtt/` mosquitto broker, as planned in `mqtt/README.md` lines 111–127.

## Before this is live (manual steps on the Pi — see `duux-emqx/README.md`)

1. Generate self-signed cert (`CN/SAN = collector3.cloudgarden.nl`)
2. Capture firmware credentials from each fan via socat MITM (one-time per fan)
3. Fill in `auth-bootstrap.json` and update usernames in `acl.conf`
4. Set UniFi DNS rewrite: `collector3.cloudgarden.nl → <PI_LAN_IP>`
5. `cd duux-emqx && docker compose up -d`
6. Reboot both fans; confirm they appear as EMQX clients
7. `cd home-assistant-amb && docker compose up -d --build`
8. Add "Duux Fan Local" integration in HA UI twice (once per fan)

## Test plan

- [x] `cd home-assistant-amb && just test` exits 0 (validates HA config)
- [x] `just build` succeeds and `duux_fan_local` dir exists under `/custom_components` in the image
- [x] Both fans appear as connected EMQX clients after reboot
- [x] Each fan creates a device in HA with fan + sensor entities
- [x] Toggling power/speed in HA actuates the physical fan
- [x] Manual fan state changes reflect back in HA