### PR TITLE
fan study: auto on/off with temp-banded speed

### DIFF
--- a/home-assistant-amb/config/automation/fan_study.yaml
+++ b/home-assistant-amb/config/automation/fan_study.yaml
@@ -7,10 +7,10 @@
   variables:
     target_pct: >
       {% set t = states('sensor.climate_study_temperature') | float(0) %}
-      {% if t >= 28 %}100
-      {% elif t >= 26 %}75
+      {% if t >= 28 %}75
+      {% elif t >= 26 %}50
       {% elif t >= 24 %}30
-      {% elif t >= 22 %}25
+      {% elif t >= 22 %}15
       {% else %}0{% endif %}
   action:
     - action: fan.set_percentage

--- a/home-assistant-amb/config/automation/fan_study.yaml
+++ b/home-assistant-amb/config/automation/fan_study.yaml
@@ -1,0 +1,33 @@
+- alias: Fan study on
+  id: fan-study-on
+  trigger:
+    - platform: state
+      entity_id: binary_sensor.workstation_in_use
+      to: "on"
+  variables:
+    target_pct: >
+      {% set t = states('sensor.climate_study_temperature') | float(0) %}
+      {% if t >= 28 %}100
+      {% elif t >= 26 %}75
+      {% elif t >= 24 %}50
+      {% elif t >= 22 %}25
+      {% else %}0{% endif %}
+  action:
+    - action: fan.set_percentage
+      data:
+        percentage: "{{ target_pct }}"
+      target:
+        entity_id: fan.fan_study
+  mode: restart
+
+- alias: Fan study off
+  id: fan-study-off
+  trigger:
+    - platform: state
+      entity_id: binary_sensor.workstation_in_use
+      to: "off"
+  action:
+    - action: fan.turn_off
+      target:
+        entity_id: fan.fan_study
+  mode: restart

--- a/home-assistant-amb/config/automation/fan_study.yaml
+++ b/home-assistant-amb/config/automation/fan_study.yaml
@@ -9,7 +9,7 @@
       {% set t = states('sensor.climate_study_temperature') | float(0) %}
       {% if t >= 28 %}100
       {% elif t >= 26 %}75
-      {% elif t >= 24 %}50
+      {% elif t >= 24 %}30
       {% elif t >= 22 %}25
       {% else %}0{% endif %}
   action:

--- a/home-assistant-amb/config/automation/fan_study.yaml
+++ b/home-assistant-amb/config/automation/fan_study.yaml
@@ -2,7 +2,7 @@
   id: fan-study-on
   trigger:
     - platform: state
-      entity_id: binary_sensor.workstation_in_use
+      entity_id: binary_sensor.workstation_in_use_immediate
       to: "on"
   variables:
     target_pct: >

--- a/home-assistant-amb/config/automation/fan_study.yaml
+++ b/home-assistant-amb/config/automation/fan_study.yaml
@@ -7,10 +7,10 @@
   variables:
     target_pct: >
       {% set t = states('sensor.climate_study_temperature') | float(0) %}
-      {% if t >= 28 %}75
-      {% elif t >= 26 %}50
-      {% elif t >= 24 %}30
-      {% elif t >= 22 %}15
+      {% if t >= 28 %}50
+      {% elif t >= 26 %}30
+      {% elif t >= 24 %}15
+      {% elif t >= 22 %}8
       {% else %}0{% endif %}
   action:
     - action: fan.set_percentage

--- a/home-assistant-amb/config/template/plug_status.yaml
+++ b/home-assistant-amb/config/template/plug_status.yaml
@@ -9,6 +9,14 @@
       delay_off:
         minutes: 1
 
+    - unique_id: workstation_in_use_immediate
+      device_class: occupancy
+      name: "Workstation in use immediate"
+      state: >
+        {{ states("sensor.plug_workstation_power") | float(0) > 60 }}
+      delay_off:
+        minutes: 1
+
     - unique_id: entertainment_in_use
       device_class: occupancy
       name: "Entertainment in use"


### PR DESCRIPTION
## Summary

- New `fan_study.yaml` automation: turns study fan on/off based on workstation use
- Turn-on triggers on `binary_sensor.workstation_in_use_immediate` (no delay_on) for instant response
- Turn-off triggers on `binary_sensor.workstation_in_use` (1-min delay_off) to avoid premature shutoff
- New `binary_sensor.workstation_in_use_immediate` added to `template/plug_status.yaml`
- Speed set at turn-on time based on `sensor.climate_study_temperature` (not re-evaluated on temp change):
  - <22C: fan off
  - 22-24C: 8%
  - 24-26C: 15%
  - 26-28C: 30%
  - `>=`28C: 50%

## Test plan

- [x] On Pi: checkout branch, reload automations + restart HA to pick up new template binary sensor
- [x] Verify `binary_sensor.workstation_in_use_immediate` appears in Developer Tools > States
- [x] Manually trigger `Fan study on`, verify fan percentage matches current temp band
- [ ] Manually trigger `Fan study off`, verify fan turns off