### PR TITLE
fan bedroom jc: auto on/off with temp-banded speed + night mode

### DIFF
--- a/home-assistant-amb/config/automation/fan_bedroom_jc.yaml
+++ b/home-assistant-amb/config/automation/fan_bedroom_jc.yaml
@@ -1,0 +1,62 @@
+- alias: Fan bedroom jc on
+  id: fan-bedroom-jc-on
+  trigger:
+    - platform: time
+      at: &turn_on_time "21:00:00"
+  variables:
+    target_pct: >
+      {% set t = states('sensor.climate_bedroom_jc_temperature') | float(0) %}
+      {% if t >= 28 %}100
+      {% elif t >= 26 %}75
+      {% elif t >= 24 %}50
+      {% elif t >= 22 %}33
+      {% else %}0{% endif %}
+  condition:
+    - condition: state
+      entity_id: binary_sensor.presence_house
+      state: "on"
+    - condition: state
+      entity_id: fan.fan_bedroom_jc
+      state: "off"
+    - condition: template
+      value_template: "{{ target_pct | int > 0 }}"
+  action:
+    - action: fan.set_percentage
+      data:
+        percentage: "{{ target_pct }}"
+      target:
+        entity_id: fan.fan_bedroom_jc
+    - action: switch.turn_off
+      target:
+        entity_id: switch.fan_bedroom_jc_night_mode
+  mode: restart
+
+- alias: Fan bedroom jc night mode on
+  id: fan-bedroom-jc-night-mode-on
+  trigger:
+    - platform: time
+      at: "22:00:00"
+  condition:
+    - condition: state
+      entity_id: fan.fan_bedroom_jc
+      state: "on"
+  action:
+    - action: switch.turn_on
+      target:
+        entity_id: switch.fan_bedroom_jc_night_mode
+  mode: restart
+
+- alias: Fan bedroom jc off
+  id: fan-bedroom-jc-off
+  trigger:
+    - platform: time
+      at: "09:00:00"
+  condition:
+    - condition: state
+      entity_id: fan.fan_bedroom_jc
+      state: "on"
+  action:
+    - action: fan.turn_off
+      target:
+        entity_id: fan.fan_bedroom_jc
+  mode: restart

--- a/home-assistant-amb/config/automation/fan_bedroom_jc.yaml
+++ b/home-assistant-amb/config/automation/fan_bedroom_jc.yaml
@@ -1,4 +1,4 @@
-- alias: Fan Bedroom JC On
+- alias: Fan Bedroom JC on
   id: fan-bedroom-jc-on
   trigger:
     - platform: time
@@ -30,7 +30,7 @@
     # if someone is sleeping in.
   mode: restart
 
-- alias: Fan Bedroom JC Night Mode On
+- alias: Fan Bedroom JC night mode on
   id: fan-bedroom-jc-night-mode-on
   trigger:
     - platform: time
@@ -45,7 +45,7 @@
         entity_id: switch.fan_bedroom_jc_night_mode
   mode: restart
 
-- alias: Fan Bedroom JC Off
+- alias: Fan Bedroom JC off
   id: fan-bedroom-jc-off
   trigger:
     - platform: time

--- a/home-assistant-amb/config/automation/fan_bedroom_jc.yaml
+++ b/home-assistant-amb/config/automation/fan_bedroom_jc.yaml
@@ -1,4 +1,4 @@
-- alias: Fan bedroom jc on
+- alias: Fan Bedroom JC On
   id: fan-bedroom-jc-on
   trigger:
     - platform: time
@@ -26,12 +26,11 @@
         percentage: "{{ target_pct }}"
       target:
         entity_id: fan.fan_bedroom_jc
-    - action: switch.turn_off
-      target:
-        entity_id: switch.fan_bedroom_jc_night_mode
+    # Night mode not turned off here: disabling it causes a beep, which is undesirable
+    # if someone is sleeping in.
   mode: restart
 
-- alias: Fan bedroom jc night mode on
+- alias: Fan Bedroom JC Night Mode On
   id: fan-bedroom-jc-night-mode-on
   trigger:
     - platform: time
@@ -46,7 +45,7 @@
         entity_id: switch.fan_bedroom_jc_night_mode
   mode: restart
 
-- alias: Fan bedroom jc off
+- alias: Fan Bedroom JC Off
   id: fan-bedroom-jc-off
   trigger:
     - platform: time


### PR DESCRIPTION
## Summary

- New `fan_bedroom_jc.yaml` with three automations
- `Fan bedroom jc on` (21:00): turns fan on if presence home + temp >=22C + fan currently off; speed based on bedroom temp at trigger time:
  - <22C: don't turn on
  - 22-24C: 33%
  - 24-26C: 50%
  - 26-28C: 75%
  - `>=`28C: 100%
  - Also turns off night mode (so beep/display are active while awake)
- `Fan bedroom jc night mode on` (22:00): enables night mode (silences beep + display) if fan is on
- `Fan bedroom jc off` (09:00): turns fan off if fan is on

## Test plan

- [ ] On Pi: checkout branch, reload automations (Developer Tools > YAML > Automations)
- [ ] Confirm entity ids exist: fan.fan_bedroom_jc, switch.fan_bedroom_jc_night_mode, sensor.climate_bedroom_jc_temperature
- [ ] Manually trigger `Fan bedroom jc on` with presence on + temp >=22, verify fan turns on at correct percentage and night mode switch is off
- [ ] Manually trigger `Fan bedroom jc night mode on` while fan on, verify switch.fan_bedroom_jc_night_mode turns on
- [ ] Manually trigger `Fan bedroom jc off`, verify fan turns off