### PR TITLE
fan dashboard: add Fans view to climate + overview section

### DIFF
--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -84,7 +84,7 @@ views:
               |---|---|---|
               | **On** | Workstation in use (plug > 60 W) | 21:00, if someone home |
               | **Off** | Workstation idle | 09:00 |
-              | **Night mode** | — | 22:00 (quieter) |
+              | **Night mode** | — | 22:00 |
               | **< 22°C** | off | off |
               | **≥ 22°C** | 8% | 33% |
               | **≥ 24°C** | 15% | 50% |

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -78,16 +78,24 @@ views:
             heading: Fans
             heading_style: title
             icon: mdi:fan
+          - type: markdown
+            content: |
+              | | Study | Bedroom JC |
+              |---|---|---|
+              | **On** | Workstation in use (plug > 60 W) | 21:00, if someone home |
+              | **Off** | Workstation idle | 09:00 |
+              | **Night mode** | — | 22:00 (quieter) |
+              | **< 22°C** | off | off |
+              | **≥ 22°C** | 8% | 33% |
+              | **≥ 24°C** | 15% | 50% |
+              | **≥ 26°C** | 30% | 75% |
+              | **≥ 28°C** | 50% | 100% |
+            grid_options:
+              columns: full
           - type: heading
             heading: Study
             heading_style: subtitle
             icon: mdi:chair-rolling
-          - type: markdown
-            content: >
-              Auto-on when workstation is in use (plug > 60 W). Speed by room temperature:
-              22°C→8%, 24°C→15%, 26°C→30%, 28°C→50%. Auto-off when workstation idle.
-            grid_options:
-              columns: full
           - type: tile
             entity: fan.fan_study
             features:
@@ -108,13 +116,6 @@ views:
             heading: Bedroom JC
             heading_style: subtitle
             icon: mdi:bed
-          - type: markdown
-            content: >
-              Auto-on at 21:00 if someone is home. Speed by room temperature:
-              22°C→33%, 24°C→50%, 26°C→75%, 28°C→100%. Night mode on at 22:00 (quieter).
-              Auto-off at 09:00.
-            grid_options:
-              columns: full
           - type: tile
             entity: fan.fan_bedroom_jc
             features:

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -82,6 +82,12 @@ views:
             heading: Study
             heading_style: subtitle
             icon: mdi:chair-rolling
+          - type: markdown
+            content: >
+              Auto-on when workstation is in use (plug > 60 W). Speed by room temperature:
+              22°C→8%, 24°C→15%, 26°C→30%, 28°C→50%. Auto-off when workstation idle.
+            grid_options:
+              columns: full
           - type: tile
             entity: fan.fan_study
             features:
@@ -102,6 +108,13 @@ views:
             heading: Bedroom JC
             heading_style: subtitle
             icon: mdi:bed
+          - type: markdown
+            content: >
+              Auto-on at 21:00 if someone is home. Speed by room temperature:
+              22°C→33%, 24°C→50%, 26°C→75%, 28°C→100%. Night mode on at 22:00 (quieter).
+              Auto-off at 09:00.
+            grid_options:
+              columns: full
           - type: tile
             entity: fan.fan_bedroom_jc
             features:

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -50,6 +50,75 @@ views:
               - entity: sensor.bedroom_jc_heating
             hours_to_show: 24
 
+  - title: Fans
+    path: fans
+    icon: mdi:fan
+    type: sections
+    badges:
+      - type: entity
+        show_name: true
+        show_state: true
+        show_icon: true
+        entity: sensor.climate_study_temperature
+        name: Study
+        icon: mdi:chair-rolling
+        color: teal
+      - type: entity
+        show_name: true
+        show_state: true
+        show_icon: true
+        entity: sensor.climate_bedroom_jc_temperature
+        name: Bedroom JC
+        icon: mdi:bed
+        color: red
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: Fans
+            heading_style: title
+            icon: mdi:fan
+          - type: heading
+            heading: Study
+            heading_style: subtitle
+            icon: mdi:chair-rolling
+          - type: tile
+            entity: fan.fan_study
+            features:
+              - type: fan-speed
+          - type: tile
+            entity: switch.fan_study_night_mode
+            name: Night Mode
+            icon: mdi:weather-night
+            tap_action:
+              action: toggle
+          - type: tile
+            entity: switch.fan_study_child_lock
+            name: Child Lock
+            icon: mdi:lock
+            tap_action:
+              action: toggle
+          - type: heading
+            heading: Bedroom JC
+            heading_style: subtitle
+            icon: mdi:bed
+          - type: tile
+            entity: fan.fan_bedroom_jc
+            features:
+              - type: fan-speed
+          - type: tile
+            entity: switch.fan_bedroom_jc_night_mode
+            name: Night Mode
+            icon: mdi:weather-night
+            tap_action:
+              action: toggle
+          - type: tile
+            entity: switch.fan_bedroom_jc_child_lock
+            name: Child Lock
+            icon: mdi:lock
+            tap_action:
+              action: toggle
+
   - title: Measurements
     path: measurements
     icon: mdi:chart-areaspline

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -209,6 +209,21 @@ views:
             features:
               - type: target-temperature
           - type: heading
+            heading: Fans
+            heading_style: subtitle
+            icon: mdi:fan
+            tap_action:
+              action: navigate
+              navigation_path: /dashboard-climate/fans
+          - type: tile
+            entity: fan.fan_study
+            features:
+              - type: fan-speed
+          - type: tile
+            entity: fan.fan_bedroom_jc
+            features:
+              - type: fan-speed
+          - type: heading
             heading_style: subtitle
             heading: Measurements
             icon: mdi:chart-areaspline


### PR DESCRIPTION
## Summary

- New **Fans** view in the Climate dashboard (between Thermostats and Measurements), with per-room subtitle sections for Study and Bedroom JC — each showing fan speed control, night mode toggle, and child lock toggle
- **Fans** subheader added to the Overview Climate section, linking to the detail view, with the two fan speed tiles for quick access
- All 6 fan entities verified live via MCP before implementation (`fan.fan_study`, `fan.fan_bedroom_jc`, `switch.*_night_mode`, `switch.*_child_lock`)

## Test plan

- [ ] `just test` passes (YAML only, no image rebuild needed)
- [ ] On Pi: pull branch + reload Lovelace → Fans view appears in Climate dashboard between Thermostats and Measurements
- [ ] Fan tiles show on/off + speed slider; night mode and child lock toggles work
- [ ] Overview Climate section shows Fans subheader navigating to `/dashboard-climate/fans`