### PR TITLE
feat: add per-floor average temperature and humidity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,11 @@ Home Assistant config uses a split configuration model (see `home-assistant-amb/
   - `automation/`: Individual automation YAML files
   - `sensor/`: Sensor definitions
   - `template/`: Template sensors and binary sensors
+    - `climate_floor_averages.yaml`: Floor-average temperature and humidity sensors
+      (`sensor.climate_{ground,first,second}_floor_{temperature,humidity}`).
+      **Attic is intentionally excluded from the second-floor average** — the attic is
+      normally closed off (fold-out stairs access only) and its temperature deviates
+      significantly from the lived-in second-floor rooms. Do not add it back.
 
 - **Individual files included** (`!include`):
   - `input_boolean.yaml`, `input_datetime.yaml`, `input_number.yaml`: User inputs

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -239,8 +239,102 @@ views:
             grid_options:
               columns: full
 
-  - title: Measurements
-    path: measurements
+  - title: Measurements per floor
+    path: measurements-per-floor
+    icon: mdi:chart-areaspline
+    type: sections
+    max_columns: 4
+    badges:
+      - type: entity
+        show_name: true
+        show_state: true
+        show_icon: true
+        entity: sensor.climate_ground_floor_temperature
+        icon: mdi:home-floor-0
+        name: Ground Floor
+        color: indigo
+      - type: entity
+        show_name: true
+        show_state: true
+        show_icon: true
+        entity: sensor.climate_first_floor_temperature
+        icon: mdi:home-floor-1
+        name: First Floor
+        color: amber
+      - type: entity
+        show_name: true
+        show_state: true
+        show_icon: true
+        entity: sensor.climate_second_floor_temperature
+        icon: mdi:home-floor-2
+        name: Second Floor
+        color: teal
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: Temperature
+            heading_style: title
+            icon: mdi:thermometer
+          - &floor_heading_1_day
+            type: heading
+            heading_style: subtitle
+            icon: ''
+            heading: 1 day
+          - type: history-graph
+            hours_to_show: 24
+            entities: &floor_entities_temperature
+              - entity: sensor.climate_ground_floor_temperature
+                name: Ground Floor
+              - entity: sensor.climate_first_floor_temperature
+                name: First Floor
+              - entity: sensor.climate_second_floor_temperature
+                name: Second Floor
+            grid_options: &floor_grid_options_temperature
+              columns: full
+              rows: 6
+          - &floor_heading_1_week
+            type: heading
+            heading_style: subtitle
+            icon: ''
+            heading: 1 week
+          - type: history-graph
+            hours_to_show: 168
+            entities: *floor_entities_temperature
+            grid_options: *floor_grid_options_temperature
+      - type: grid
+        cards:
+          - type: heading
+            heading: Humidity
+            heading_style: title
+            icon: mdi:water-percent
+          - *floor_heading_1_day
+          - type: history-graph
+            hours_to_show: 24
+            entities: &floor_entities_humidity
+              - entity: sensor.climate_ground_floor_humidity
+                name: Ground Floor
+              - entity: sensor.climate_first_floor_humidity
+                name: First Floor
+              - entity: sensor.climate_second_floor_humidity
+                name: Second Floor
+            min_y_axis: &floor_min_y_axis_humidity 30
+            max_y_axis: &floor_max_y_axis_humidity 80
+            fit_y_data: true
+            grid_options: &floor_grid_options_humidity
+              columns: 12
+              rows: 6
+          - *floor_heading_1_week
+          - type: history-graph
+            hours_to_show: 168
+            entities: *floor_entities_humidity
+            min_y_axis: *floor_min_y_axis_humidity
+            max_y_axis: *floor_max_y_axis_humidity
+            fit_y_data: true
+            grid_options: *floor_grid_options_humidity
+
+  - title: Measurements per room
+    path: measurements-per-room
     icon: mdi:chart-areaspline
     type: sections
     max_columns: 4

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -241,7 +241,7 @@ views:
 
   - title: Measurements per floor
     path: measurements-per-floor
-    icon: mdi:chart-areaspline
+    icon: mdi:chart-areaspline-variant
     type: sections
     max_columns: 4
     badges:

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -70,33 +70,25 @@ views:
         show_name: true
         show_state: true
         show_icon: true
-        entity: sensor.climate_living_temperature
-        icon: mdi:sofa
-        name: Living
+        entity: sensor.climate_ground_floor_temperature
+        icon: mdi:home-floor-0
+        name: Ground Floor
         color: indigo
       - type: entity
         show_name: true
         show_state: true
         show_icon: true
-        entity: sensor.climate_bathroom_temperature
-        name: Bathroom
-        icon: mdi:shower-head
+        entity: sensor.climate_first_floor_temperature
+        icon: mdi:home-floor-1
+        name: First Floor
         color: amber
       - type: entity
         show_name: true
         show_state: true
         show_icon: true
-        entity: sensor.climate_bedroom_jc_temperature
-        icon: mdi:bed
-        name: Bedroom JC
-        color: red
-      - type: entity
-        show_name: true
-        show_state: true
-        show_icon: true
-        entity: sensor.climate_study_temperature
-        name: Study
-        icon: mdi:chair-rolling
+        entity: sensor.climate_second_floor_temperature
+        icon: mdi:home-floor-2
+        name: Second Floor
         color: teal
     sections:
       - type: grid
@@ -229,32 +221,28 @@ views:
             icon: mdi:chart-areaspline
             tap_action:
               action: navigate
-              navigation_path: /dashboard-climate/measurements
+              navigation_path: /dashboard-climate/measurements-per-floor
           - type: history-graph
             hours_to_show: 24
             entities:
-              - entity: sensor.climate_living_temperature
-                name: Living
-              - entity: sensor.climate_bathroom_temperature
-                name: Bathroom
-              - entity: sensor.climate_bedroom_jc_temperature
-                name: Bedroom JC
-              - entity: sensor.climate_study_temperature
-                name: Study
+              - entity: sensor.climate_ground_floor_temperature
+                name: Ground Floor
+              - entity: sensor.climate_first_floor_temperature
+                name: First Floor
+              - entity: sensor.climate_second_floor_temperature
+                name: Second Floor
             grid_options:
               columns: 12
               rows: 4
           - type: history-graph
             hours_to_show: 24
             entities:
-              - entity: sensor.climate_living_humidity
-                name: Living
-              - entity: sensor.climate_bathroom_humidity
-                name: Bathroom
-              - entity: sensor.climate_bedroom_jc_humidity
-                name: Bedroom JC
-              - entity: sensor.climate_study_humidity
-                name: Study
+              - entity: sensor.climate_ground_floor_humidity
+                name: Ground Floor
+              - entity: sensor.climate_first_floor_humidity
+                name: First Floor
+              - entity: sensor.climate_second_floor_humidity
+                name: Second Floor
             min_y_axis: 30
             max_y_axis: 80
             fit_y_data: true

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -218,7 +218,7 @@ views:
           - type: heading
             heading_style: subtitle
             heading: Measurements
-            icon: mdi:chart-areaspline
+            icon: mdi:chart-areaspline-variant
             tap_action:
               action: navigate
               navigation_path: /dashboard-climate/measurements-per-floor

--- a/home-assistant-amb/config/template/climate_floor_averages.yaml
+++ b/home-assistant-amb/config/template/climate_floor_averages.yaml
@@ -1,0 +1,123 @@
+- sensor:
+  # Ground floor: only one climate-sensor room (Living), so blend the Zigbee sensor
+  # with the Tado thermostat's reading for a slightly more stable average.
+  - name: Climate Ground Floor Temperature
+    unique_id: climate_ground_floor_temperature
+    unit_of_measurement: °C
+    device_class: temperature
+    state_class: measurement
+    # float(none): unavailable/dead sensor → None; select('is_number') drops it so it
+    # doesn't drag the average. float(0) would inject a fake 0 °C instead.
+    availability: >-
+      {{ [
+        states('sensor.climate_living_temperature') | float(none),
+        states('sensor.tado_smart_thermostat_ru1574584320_current_temperature') | float(none)
+      ] | select('is_number') | list | count > 0 }}
+    state: >-
+      {% set vals = [
+        states('sensor.climate_living_temperature') | float(none),
+        states('sensor.tado_smart_thermostat_ru1574584320_current_temperature') | float(none)
+      ] | select('is_number') | list %}
+      {{ ((vals | sum) / (vals | count)) | round(1) }}
+
+  - name: Climate First Floor Temperature
+    unique_id: climate_first_floor_temperature
+    unit_of_measurement: °C
+    device_class: temperature
+    state_class: measurement
+    availability: >-
+      {{ [
+        states('sensor.climate_bathroom_temperature') | float(none),
+        states('sensor.climate_laundry_temperature') | float(none),
+        states('sensor.climate_bedroom_jc_temperature') | float(none),
+        states('sensor.climate_bedroom_olivier_temperature') | float(none)
+      ] | select('is_number') | list | count > 0 }}
+    state: >-
+      {% set vals = [
+        states('sensor.climate_bathroom_temperature') | float(none),
+        states('sensor.climate_laundry_temperature') | float(none),
+        states('sensor.climate_bedroom_jc_temperature') | float(none),
+        states('sensor.climate_bedroom_olivier_temperature') | float(none)
+      ] | select('is_number') | list %}
+      {{ ((vals | sum) / (vals | count)) | round(1) }}
+
+  # Attic is intentionally excluded from the second-floor average: it is normally
+  # closed off (accessible only via fold-out stairs) and its temperature deviates
+  # significantly from the lived-in rooms (Study, Bedroom Duco, Utility).
+  # Attic still appears on the per-room Measurements page.
+  - name: Climate Second Floor Temperature
+    unique_id: climate_second_floor_temperature
+    unit_of_measurement: °C
+    device_class: temperature
+    state_class: measurement
+    availability: >-
+      {{ [
+        states('sensor.climate_utility_temperature') | float(none),
+        states('sensor.climate_bedroom_duco_temperature') | float(none),
+        states('sensor.climate_study_temperature') | float(none)
+      ] | select('is_number') | list | count > 0 }}
+    state: >-
+      {% set vals = [
+        states('sensor.climate_utility_temperature') | float(none),
+        states('sensor.climate_bedroom_duco_temperature') | float(none),
+        states('sensor.climate_study_temperature') | float(none)
+      ] | select('is_number') | list %}
+      {{ ((vals | sum) / (vals | count)) | round(1) }}
+
+  - name: Climate Ground Floor Humidity
+    unique_id: climate_ground_floor_humidity
+    unit_of_measurement: '%'
+    device_class: humidity
+    state_class: measurement
+    availability: >-
+      {{ [
+        states('sensor.climate_living_humidity') | float(none),
+        states('sensor.tado_smart_thermostat_ru1574584320_current_humidity') | float(none)
+      ] | select('is_number') | list | count > 0 }}
+    state: >-
+      {% set vals = [
+        states('sensor.climate_living_humidity') | float(none),
+        states('sensor.tado_smart_thermostat_ru1574584320_current_humidity') | float(none)
+      ] | select('is_number') | list %}
+      {{ ((vals | sum) / (vals | count)) | round(1) }}
+
+  - name: Climate First Floor Humidity
+    unique_id: climate_first_floor_humidity
+    unit_of_measurement: '%'
+    device_class: humidity
+    state_class: measurement
+    availability: >-
+      {{ [
+        states('sensor.climate_bathroom_humidity') | float(none),
+        states('sensor.climate_laundry_humidity') | float(none),
+        states('sensor.climate_bedroom_jc_humidity') | float(none),
+        states('sensor.climate_bedroom_olivier_humidity') | float(none)
+      ] | select('is_number') | list | count > 0 }}
+    state: >-
+      {% set vals = [
+        states('sensor.climate_bathroom_humidity') | float(none),
+        states('sensor.climate_laundry_humidity') | float(none),
+        states('sensor.climate_bedroom_jc_humidity') | float(none),
+        states('sensor.climate_bedroom_olivier_humidity') | float(none)
+      ] | select('is_number') | list %}
+      {{ ((vals | sum) / (vals | count)) | round(1) }}
+
+  # Attic excluded — same reason as temperature above.
+  - name: Climate Second Floor Humidity
+    unique_id: climate_second_floor_humidity
+    unit_of_measurement: '%'
+    device_class: humidity
+    state_class: measurement
+    availability: >-
+      {{ [
+        states('sensor.climate_utility_humidity') | float(none),
+        states('sensor.climate_bedroom_duco_humidity') | float(none),
+        states('sensor.climate_study_humidity') | float(none)
+      ] | select('is_number') | list | count > 0 }}
+    state: >-
+      {% set vals = [
+        states('sensor.climate_utility_humidity') | float(none),
+        states('sensor.climate_bedroom_duco_humidity') | float(none),
+        states('sensor.climate_study_humidity') | float(none)
+      ] | select('is_number') | list %}
+      {{ ((vals | sum) / (vals | count)) | round(1) }}


### PR DESCRIPTION
## Summary

- New template sensors (`template/climate_floor_averages.yaml`) compute floor-average temperature and humidity for ground / first / second floor. Dead sensors are excluded via `float(none)` + `select('is_number')` — a flat battery won't corrupt the average.
- Attic excluded from second-floor average (normally closed off via fold-out stairs; temp deviates from lived-in rooms).
- **Overview**: 4 per-room temp badges → 3 floor badges; both Measurements graphs (temp + humidity) show floor averages; nav link → `measurements-per-floor`.
- **Climate dashboard**: existing Measurements view renamed to "Measurements per room" (`path: measurements-per-room`); new "Measurements per floor" view added with 1-day + 1-week temp and humidity floor graphs.
- `CLAUDE.md` updated to document the Attic exclusion.

## Test plan

- [x] `cd home-assistant-amb && just test` passes (already verified locally)
- [x] On Pi: checkout branch + reload configuration via UI (config-only, no Docker rebuild needed)
- [x] HA Developer Tools → States: confirm `sensor.climate_{ground,first,second}_floor_{temperature,humidity}` show numeric values
- [x] Overview: 3 floor temp badges visible, both graphs show 3 lines, Measurements link navigates to per-floor page
- [x] Climate dashboard: two Measurements views in tab order (per floor, per room); per-floor page shows 3-line temp + humidity graphs