### PR TITLE
feat: add inside vs outside temperature ApexCharts card

### DIFF
--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -1,8 +1,9 @@
 views:
-  - title: Temperature
-    path: temperature
-    icon: mdi:chart-areaspline-variant
+  - title: Inside vs Outside
+    path: inside-vs-outside
+    icon: mdi:sun-thermometer
     type: sections
+    max_columns: 1
     sections:
       - type: grid
         cards:

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -24,9 +24,6 @@ views:
       - type: grid
         cards:
           - type: custom:apexcharts-card
-            grid_options:
-              columns: full
-              rows: 6
             apex_config:
               chart:
                 height: 400px

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -23,7 +23,7 @@ views:
               tickAmount: 9
         hours_12: false
         all_series_config:
-          stroke_width: 2
+          stroke_width: 3
           fill_raw: last
         series:
           - entity: sensor.climate_ground_floor_temperature
@@ -33,21 +33,21 @@ views:
             color: "#3F51B5"
             opacity: 0.5
             type: line
-            stroke_width: 2
+            stroke_width: 3
           - entity: sensor.climate_first_floor_temperature
             name: First floor
             extend_to: now
-            color: "#FF8F00"
+            color: "#FFC107"
             opacity: 0.5
             type: line
-            stroke_width: 2
+            stroke_width: 3
           - entity: sensor.climate_second_floor_temperature
             name: Second floor
             extend_to: now
             color: "#F44336"
             opacity: 0.5
             type: line
-            stroke_width: 2
+            stroke_width: 3
           - entity: sensor.openweathermap_temperature
             name: Outside
             extend_to: now

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -31,21 +31,21 @@ views:
             unit: "°C"
             extend_to: now
             color: "#3F51B5"
-            opacity: 0.5
+            opacity: 0.9
             type: line
             stroke_width: 3
           - entity: sensor.climate_first_floor_temperature
             name: First floor
             extend_to: now
             color: "#FFC107"
-            opacity: 0.5
+            opacity: 0.9
             type: line
             stroke_width: 3
           - entity: sensor.climate_second_floor_temperature
             name: Second floor
             extend_to: now
             color: "#F44336"
-            opacity: 0.5
+            opacity: 0.9
             type: line
             stroke_width: 3
           - entity: sensor.openweathermap_temperature

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -30,21 +30,21 @@ views:
             name: Ground floor
             unit: "°C"
             extend_to: now
-            color: green
+            color: "#3F51B5"
             opacity: 0.5
             type: line
             stroke_width: 2
           - entity: sensor.climate_first_floor_temperature
             name: First floor
             extend_to: now
-            color: blue
+            color: "#FF8F00"
             opacity: 0.5
             type: line
             stroke_width: 2
           - entity: sensor.climate_second_floor_temperature
             name: Second floor
             extend_to: now
-            color: orange
+            color: "#F44336"
             opacity: 0.5
             type: line
             stroke_width: 2

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -23,6 +23,100 @@ views:
     sections:
       - type: grid
         cards:
+          - type: custom:apexcharts-card
+            grid_options:
+              columns: full
+              rows: 6
+            apex_config:
+              chart:
+                height: 400px
+            header:
+              title: Inside versus outside temperature 24h
+              show: true
+              show_states: true
+              colorize_states: true
+            graph_span: 24h
+            span:
+              offset: +8h
+            yaxis:
+              - min: 18
+                decimals: 0
+                apex_config:
+                  tickAmount: 9
+            hours_12: false
+            all_series_config:
+              stroke_width: 2
+              fill_raw: last
+            series:
+              - entity: sensor.climate_ground_floor_temperature
+                name: Ground floor
+                unit: "°C"
+                extend_to: now
+                color: green
+                opacity: 0.5
+                type: line
+                stroke_width: 2
+              - entity: sensor.climate_first_floor_temperature
+                name: First floor
+                extend_to: now
+                color: blue
+                opacity: 0.5
+                type: line
+                stroke_width: 2
+              - entity: sensor.climate_second_floor_temperature
+                name: Second floor
+                extend_to: now
+                color: orange
+                opacity: 0.5
+                type: line
+                stroke_width: 2
+              - entity: sensor.openweathermap_temperature
+                name: Outside
+                extend_to: now
+                color: "#a8a8a8"
+                opacity: 0.3
+                type: area
+                stroke_width: 0
+              - entity: sensor.weather_forecast_hourly
+                name: Outside forecast
+                unit: "°C"
+                color: "#cccccc"
+                opacity: 0.3
+                type: area
+                stroke_width: 0
+                extend_to: end
+                show:
+                  in_header: false
+                  legend_value: false
+                data_generator: >
+                  const forecast = entity.attributes.forecast;
+                  if (!forecast || !forecast.length) return [];
+                  const now = Date.now();
+                  const future = forecast.filter(e => new Date(e.datetime).getTime() > now);
+                  const past = forecast.filter(e => new Date(e.datetime).getTime() <= now);
+                  if (!future.length) return [];
+                  const prev = past[past.length - 1];
+                  const next = future[0];
+                  let nowTemp;
+                  if (prev && next) {
+                    const t0 = new Date(prev.datetime).getTime();
+                    const t1 = new Date(next.datetime).getTime();
+                    const ratio = (now - t0) / (t1 - t0);
+                    nowTemp = prev.temperature + ratio * (next.temperature - prev.temperature);
+                  } else {
+                    nowTemp = next.temperature;
+                  }
+                  return [[now, nowTemp], ...future.map(e => [new Date(e.datetime).getTime(), e.temperature])];
+          - type: heading
+            heading: Heating percentage 24h
+            heading_style: subtitle
+            icon: mdi:heat-wave
+          - type: history-graph
+            entities:
+              - entity: sensor.living_heating
+              - entity: sensor.study_heating
+              - entity: sensor.bedroom_jc_heating
+            hours_to_show: 24
           - type: heading
             heading: Thermostats
             heading_style: title
@@ -39,16 +133,6 @@ views:
             entity: climate.bedroom_jc
             features:
               - type: target-temperature
-          - type: heading
-            heading: Heating percentage 24h
-            heading_style: subtitle
-            icon: mdi:heat-wave
-          - type: history-graph
-            entities:
-              - entity: sensor.living_heating
-              - entity: sensor.study_heating
-              - entity: sensor.bedroom_jc_heating
-            hours_to_show: 24
 
   - title: Fans
     path: fans

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -2,92 +2,89 @@ views:
   - title: Inside vs Outside
     path: inside-vs-outside
     icon: mdi:sun-thermometer
-    type: sections
-    max_columns: 1
-    sections:
-      - type: grid
-        cards:
-          - type: custom:apexcharts-card
+    type: panel
+    cards:
+      - type: custom:apexcharts-card
+        apex_config:
+          chart:
+            height: 400px
+        header:
+          title: Inside versus outside temperature 24h
+          show: true
+          show_states: true
+          colorize_states: true
+        graph_span: 24h
+        span:
+          offset: +8h
+        yaxis:
+          - min: 18
+            decimals: 0
             apex_config:
-              chart:
-                height: 400px
-            header:
-              title: Inside versus outside temperature 24h
-              show: true
-              show_states: true
-              colorize_states: true
-            graph_span: 24h
-            span:
-              offset: +8h
-            yaxis:
-              - min: 18
-                decimals: 0
-                apex_config:
-                  tickAmount: 9
-            hours_12: false
-            all_series_config:
-              stroke_width: 2
-              fill_raw: last
-            series:
-              - entity: sensor.climate_ground_floor_temperature
-                name: Ground floor
-                unit: "°C"
-                extend_to: now
-                color: green
-                opacity: 0.5
-                type: line
-                stroke_width: 2
-              - entity: sensor.climate_first_floor_temperature
-                name: First floor
-                extend_to: now
-                color: blue
-                opacity: 0.5
-                type: line
-                stroke_width: 2
-              - entity: sensor.climate_second_floor_temperature
-                name: Second floor
-                extend_to: now
-                color: orange
-                opacity: 0.5
-                type: line
-                stroke_width: 2
-              - entity: sensor.openweathermap_temperature
-                name: Outside
-                extend_to: now
-                color: "#a8a8a8"
-                opacity: 0.3
-                type: area
-                stroke_width: 0
-              - entity: sensor.weather_forecast_hourly
-                name: Outside forecast
-                unit: "°C"
-                color: "#cccccc"
-                opacity: 0.3
-                type: area
-                stroke_width: 0
-                extend_to: end
-                show:
-                  in_header: false
-                  legend_value: false
-                data_generator: >
-                  const forecast = entity.attributes.forecast;
-                  if (!forecast || !forecast.length) return [];
-                  const now = Date.now();
-                  const future = forecast.filter(e => new Date(e.datetime).getTime() > now);
-                  const past = forecast.filter(e => new Date(e.datetime).getTime() <= now);
-                  if (!future.length) return [];
-                  const prev = past[past.length - 1];
-                  const next = future[0];
-                  let nowTemp;
-                  if (prev && next) {
-                    const t0 = new Date(prev.datetime).getTime();
-                    const t1 = new Date(next.datetime).getTime();
-                    const ratio = (now - t0) / (t1 - t0);
-                    nowTemp = prev.temperature + ratio * (next.temperature - prev.temperature);
-                  } else {
-                    nowTemp = next.temperature;
-                  }
-                  return [[now, nowTemp], ...future.map(e => [new Date(e.datetime).getTime(), e.temperature])];
+              tickAmount: 9
+        hours_12: false
+        all_series_config:
+          stroke_width: 2
+          fill_raw: last
+        series:
+          - entity: sensor.climate_ground_floor_temperature
+            name: Ground floor
+            unit: "°C"
+            extend_to: now
+            color: green
+            opacity: 0.5
+            type: line
+            stroke_width: 2
+          - entity: sensor.climate_first_floor_temperature
+            name: First floor
+            extend_to: now
+            color: blue
+            opacity: 0.5
+            type: line
+            stroke_width: 2
+          - entity: sensor.climate_second_floor_temperature
+            name: Second floor
+            extend_to: now
+            color: orange
+            opacity: 0.5
+            type: line
+            stroke_width: 2
+          - entity: sensor.openweathermap_temperature
+            name: Outside
+            extend_to: now
+            color: "#a8a8a8"
+            opacity: 0.3
+            type: area
+            stroke_width: 0
+          - entity: sensor.weather_forecast_hourly
+            name: Outside forecast
+            unit: "°C"
+            color: "#cccccc"
+            opacity: 0.3
+            type: area
+            stroke_width: 0
+            extend_to: end
+            show:
+              in_header: false
+              legend_value: false
+            data_generator: >
+              const forecast = entity.attributes.forecast;
+              if (!forecast || !forecast.length) return [];
+              const now = Date.now();
+              const future = forecast.filter(e => new Date(e.datetime).getTime() > now);
+              const past = forecast.filter(e => new Date(e.datetime).getTime() <= now);
+              if (!future.length) return [];
+              const prev = past[past.length - 1];
+              const next = future[0];
+              let nowTemp;
+              if (prev && next) {
+                const t0 = new Date(prev.datetime).getTime();
+                const t1 = new Date(next.datetime).getTime();
+                const ratio = (now - t0) / (t1 - t0);
+                nowTemp = prev.temperature + ratio * (next.temperature - prev.temperature);
+              } else {
+                nowTemp = next.temperature;
+              }
+              return [[now, nowTemp], ...future.map(e => [new Date(e.datetime).getTime(), e.temperature])];
 
   - title: Fans
     path: fans

--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -1,25 +1,8 @@
 views:
-  - title: Thermostats
-    path: thermostats
-    icon: mdi:thermostat
+  - title: Temperature
+    path: temperature
+    icon: mdi:chart-areaspline-variant
     type: sections
-    badges:
-      - type: entity
-        entity: binary_sensor.ib1863854592_connection_state
-        name: Internet Bridge
-        show_name: true
-      - type: entity
-        entity: binary_sensor.tado_thermostat_living_battery
-        name: Living
-        show_name: true
-      - type: entity
-        entity: binary_sensor.tado_thermostat_bedroom_jc_battery
-        name: Bedroom JC
-        show_name: true
-      - type: entity
-        entity: binary_sensor.tado_thermostat_valve_study_battery
-        name: Study
-        show_name: true
     sections:
       - type: grid
         cards:
@@ -104,32 +87,6 @@ views:
                     nowTemp = next.temperature;
                   }
                   return [[now, nowTemp], ...future.map(e => [new Date(e.datetime).getTime(), e.temperature])];
-          - type: heading
-            heading: Heating percentage 24h
-            heading_style: subtitle
-            icon: mdi:heat-wave
-          - type: history-graph
-            entities:
-              - entity: sensor.living_heating
-              - entity: sensor.study_heating
-              - entity: sensor.bedroom_jc_heating
-            hours_to_show: 24
-          - type: heading
-            heading: Thermostats
-            heading_style: title
-            icon: mdi:thermostat
-          - type: tile
-            entity: climate.living
-            features:
-              - type: target-temperature
-          - type: tile
-            entity: climate.study
-            features:
-              - type: target-temperature
-          - type: tile
-            entity: climate.bedroom_jc
-            features:
-              - type: target-temperature
 
   - title: Fans
     path: fans
@@ -579,3 +536,54 @@ views:
             max_y_axis: *max_y_axis_humidity
             fit_y_data: true
             grid_options: *grid_options_humidity
+
+  - title: Thermostats
+    path: thermostats
+    icon: mdi:thermostat
+    type: sections
+    badges:
+      - type: entity
+        entity: binary_sensor.ib1863854592_connection_state
+        name: Internet Bridge
+        show_name: true
+      - type: entity
+        entity: binary_sensor.tado_thermostat_living_battery
+        name: Living
+        show_name: true
+      - type: entity
+        entity: binary_sensor.tado_thermostat_bedroom_jc_battery
+        name: Bedroom JC
+        show_name: true
+      - type: entity
+        entity: binary_sensor.tado_thermostat_valve_study_battery
+        name: Study
+        show_name: true
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: Thermostats
+            heading_style: title
+            icon: mdi:thermostat
+          - type: tile
+            entity: climate.living
+            features:
+              - type: target-temperature
+          - type: tile
+            entity: climate.study
+            features:
+              - type: target-temperature
+          - type: tile
+            entity: climate.bedroom_jc
+            features:
+              - type: target-temperature
+          - type: heading
+            heading: Heating percentage 24h
+            heading_style: subtitle
+            icon: mdi:heat-wave
+          - type: history-graph
+            entities:
+              - entity: sensor.living_heating
+              - entity: sensor.study_heating
+              - entity: sensor.bedroom_jc_heating
+            hours_to_show: 24

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -219,21 +219,21 @@ views:
                 unit: "°C"
                 extend_to: now
                 color: "#3F51B5"
-                opacity: 0.5
+                opacity: 0.9
                 type: line
                 stroke_width: 3
               - entity: sensor.climate_first_floor_temperature
                 name: First floor
                 extend_to: now
                 color: "#FFC107"
-                opacity: 0.5
+                opacity: 0.9
                 type: line
                 stroke_width: 3
               - entity: sensor.climate_second_floor_temperature
                 name: Second floor
                 extend_to: now
                 color: "#F44336"
-                opacity: 0.5
+                opacity: 0.9
                 type: line
                 stroke_width: 3
               - entity: sensor.openweathermap_temperature
@@ -290,7 +290,7 @@ views:
               - type: fan-speed
           - type: heading
             heading_style: subtitle
-            heading: Measurements
+            heading: Measurements per floor
             icon: mdi:chart-areaspline-variant
             tap_action:
               action: navigate
@@ -310,6 +310,13 @@ views:
             grid_options:
               columns: 12
               rows: 4
+          - type: heading
+            heading_style: subtitle
+            heading: Measurements per room
+            icon: mdi:chart-areaspline
+            tap_action:
+              action: navigate
+              navigation_path: /dashboard-climate/measurements-per-room
           - type: heading
             heading: Thermostats
             heading_style: subtitle

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -211,7 +211,7 @@ views:
                   tickAmount: 9
             hours_12: false
             all_series_config:
-              stroke_width: 2
+              stroke_width: 3
               fill_raw: last
             series:
               - entity: sensor.climate_ground_floor_temperature
@@ -221,21 +221,21 @@ views:
                 color: "#3F51B5"
                 opacity: 0.5
                 type: line
-                stroke_width: 2
+                stroke_width: 3
               - entity: sensor.climate_first_floor_temperature
                 name: First floor
                 extend_to: now
-                color: "#FF8F00"
+                color: "#FFC107"
                 opacity: 0.5
                 type: line
-                stroke_width: 2
+                stroke_width: 3
               - entity: sensor.climate_second_floor_temperature
                 name: Second floor
                 extend_to: now
                 color: "#F44336"
                 opacity: 0.5
                 type: line
-                stroke_width: 2
+                stroke_width: 3
               - entity: sensor.openweathermap_temperature
                 name: Outside
                 extend_to: now

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -186,15 +186,6 @@ views:
             heading_style: title
             icon: mdi:thermometer
           - type: custom:apexcharts-card
-            grid_options:
-              columns: 12
-              rows: 3
-            series:
-              - entity: sensor.climate_ground_floor_temperature
-          - type: custom:apexcharts-card
-            grid_options:
-              columns: 12
-              rows: 6
             apex_config:
               chart:
                 height: 400px

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -218,21 +218,21 @@ views:
                 name: Ground floor
                 unit: "°C"
                 extend_to: now
-                color: green
+                color: "#3F51B5"
                 opacity: 0.5
                 type: line
                 stroke_width: 2
               - entity: sensor.climate_first_floor_temperature
                 name: First floor
                 extend_to: now
-                color: blue
+                color: "#FF8F00"
                 opacity: 0.5
                 type: line
                 stroke_width: 2
               - entity: sensor.climate_second_floor_temperature
                 name: Second floor
                 extend_to: now
-                color: orange
+                color: "#F44336"
                 opacity: 0.5
                 type: line
                 stroke_width: 2

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -188,6 +188,12 @@ views:
           - type: custom:apexcharts-card
             grid_options:
               columns: 12
+              rows: 3
+            series:
+              - entity: sensor.climate_ground_floor_temperature
+          - type: custom:apexcharts-card
+            grid_options:
+              columns: 12
               rows: 6
             apex_config:
               chart:

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -186,12 +186,12 @@ views:
             heading_style: title
             icon: mdi:thermometer
           - type: heading
-            heading: Temperature
+            heading: Inside vs Outside
             heading_style: subtitle
-            icon: mdi:chart-areaspline-variant
+            icon: mdi:sun-thermometer
             tap_action:
               action: navigate
-              navigation_path: /dashboard-climate/temperature
+              navigation_path: /dashboard-climate/inside-vs-outside
           - type: custom:apexcharts-card
             apex_config:
               chart:

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -185,10 +185,17 @@ views:
             heading: Climate
             heading_style: title
             icon: mdi:thermometer
+          - type: heading
+            heading: Temperature
+            heading_style: subtitle
+            icon: mdi:chart-areaspline-variant
+            tap_action:
+              action: navigate
+              navigation_path: /dashboard-climate/temperature
           - type: custom:apexcharts-card
             apex_config:
               chart:
-                height: 400px
+                height: 280px
             header:
               title: Inside versus outside temperature 24h
               show: true

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -185,21 +185,90 @@ views:
             heading: Climate
             heading_style: title
             icon: mdi:thermometer
-          - type: heading
-            heading: Thermostats
-            heading_style: subtitle
-            icon: mdi:thermostat-box
-            tap_action:
-              action: navigate
-              navigation_path: /dashboard-climate/thermostats
-          - type: tile
-            entity: climate.living
-            features:
-              - type: target-temperature
-          - type: tile
-            entity: climate.study
-            features:
-              - type: target-temperature
+          - type: custom:apexcharts-card
+            grid_options:
+              columns: 12
+              rows: 6
+            apex_config:
+              chart:
+                height: 400px
+            header:
+              title: Inside versus outside temperature 24h
+              show: true
+              show_states: true
+              colorize_states: true
+            graph_span: 24h
+            span:
+              offset: +8h
+            yaxis:
+              - min: 18
+                decimals: 0
+                apex_config:
+                  tickAmount: 9
+            hours_12: false
+            all_series_config:
+              stroke_width: 2
+              fill_raw: last
+            series:
+              - entity: sensor.climate_ground_floor_temperature
+                name: Ground floor
+                unit: "°C"
+                extend_to: now
+                color: green
+                opacity: 0.5
+                type: line
+                stroke_width: 2
+              - entity: sensor.climate_first_floor_temperature
+                name: First floor
+                extend_to: now
+                color: blue
+                opacity: 0.5
+                type: line
+                stroke_width: 2
+              - entity: sensor.climate_second_floor_temperature
+                name: Second floor
+                extend_to: now
+                color: orange
+                opacity: 0.5
+                type: line
+                stroke_width: 2
+              - entity: sensor.openweathermap_temperature
+                name: Outside
+                extend_to: now
+                color: "#a8a8a8"
+                opacity: 0.3
+                type: area
+                stroke_width: 0
+              - entity: sensor.weather_forecast_hourly
+                name: Outside forecast
+                unit: "°C"
+                color: "#cccccc"
+                opacity: 0.3
+                type: area
+                stroke_width: 0
+                extend_to: end
+                show:
+                  in_header: false
+                  legend_value: false
+                data_generator: >
+                  const forecast = entity.attributes.forecast;
+                  if (!forecast || !forecast.length) return [];
+                  const now = Date.now();
+                  const future = forecast.filter(e => new Date(e.datetime).getTime() > now);
+                  const past = forecast.filter(e => new Date(e.datetime).getTime() <= now);
+                  if (!future.length) return [];
+                  const prev = past[past.length - 1];
+                  const next = future[0];
+                  let nowTemp;
+                  if (prev && next) {
+                    const t0 = new Date(prev.datetime).getTime();
+                    const t1 = new Date(next.datetime).getTime();
+                    const ratio = (now - t0) / (t1 - t0);
+                    nowTemp = prev.temperature + ratio * (next.temperature - prev.temperature);
+                  } else {
+                    nowTemp = next.temperature;
+                  }
+                  return [[now, nowTemp], ...future.map(e => [new Date(e.datetime).getTime(), e.temperature])];
           - type: heading
             heading: Fans
             heading_style: subtitle
@@ -225,18 +294,6 @@ views:
           - type: history-graph
             hours_to_show: 24
             entities:
-              - entity: sensor.climate_ground_floor_temperature
-                name: Ground Floor
-              - entity: sensor.climate_first_floor_temperature
-                name: First Floor
-              - entity: sensor.climate_second_floor_temperature
-                name: Second Floor
-            grid_options:
-              columns: 12
-              rows: 4
-          - type: history-graph
-            hours_to_show: 24
-            entities:
               - entity: sensor.climate_ground_floor_humidity
                 name: Ground Floor
               - entity: sensor.climate_first_floor_humidity
@@ -249,6 +306,21 @@ views:
             grid_options:
               columns: 12
               rows: 4
+          - type: heading
+            heading: Thermostats
+            heading_style: subtitle
+            icon: mdi:thermostat-box
+            tap_action:
+              action: navigate
+              navigation_path: /dashboard-climate/thermostats
+          - type: tile
+            entity: climate.living
+            features:
+              - type: target-temperature
+          - type: tile
+            entity: climate.study
+            features:
+              - type: target-temperature
       - type: grid
         cards:
           - type: heading

--- a/home-assistant-amb/config/template/weather_forecast.yaml
+++ b/home-assistant-amb/config/template/weather_forecast.yaml
@@ -1,0 +1,20 @@
+- trigger:
+    - trigger: time_pattern
+      minutes: "/30"
+    - trigger: homeassistant
+      event: start
+  action:
+    - action: weather.get_forecasts
+      target:
+        entity_id: weather.openweathermap
+      data:
+        type: hourly
+      response_variable: hourly
+  sensor:
+    - name: Weather Forecast Hourly
+      unique_id: weather_forecast_hourly
+      state: "{{ hourly['weather.openweathermap'].forecast[0].temperature }}"
+      unit_of_measurement: "°C"
+      device_class: temperature
+      attributes:
+        forecast: "{{ hourly['weather.openweathermap'].forecast }}"

--- a/home-assistant-amb/config/template/weather_forecast.yaml
+++ b/home-assistant-amb/config/template/weather_forecast.yaml
@@ -1,6 +1,6 @@
 - trigger:
-    - trigger: time_pattern
-      minutes: "/30"
+    - trigger: state
+      entity_id: weather.openweathermap
     - trigger: homeassistant
       event: start
   action:

--- a/home-assistant-amb/docker/Dockerfile
+++ b/home-assistant-amb/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN cd /tmp \
     && mv duux-fan-local-${DUUX_FAN_LOCAL_VERSION}/custom_components/duux_fan_local ${CUSTOM_COMPONENTS_DIR} \
     && rm -rf /tmp/*
 
-# Add apexcharts-card (Lovelace custom card — kept for reference, not currently used for fan graph)
+# Add apexcharts-card (Lovelace custom card - used by the inside vs outside temperature chart on the overview + climate dashboards)
 ARG APEXCHARTS_CARD_VERSION=v2.1.2
 RUN mkdir -p /www \
     && wget -O /www/apexcharts-card.js \


### PR DESCRIPTION
## Summary

- Add `sensor.weather_forecast_hourly` trigger-based template sensor to re-expose the OWM hourly forecast as an attribute (HA 2026 removed the `forecast` attribute from weather entities; this restores the shape the `data_generator` expects)
- Insert ApexCharts card (ground/first/second floor + outside current + outside forecast) at the top of the Climate section on the overview dashboard; move thermostat tiles to the bottom; remove the now-redundant temperature history-graph from Measurements
- Same chart inserted at the top of the Thermostats view on the climate dashboard; thermostat tiles moved to the bottom
- Update stale Dockerfile comment on apexcharts-card to reflect actual usage

## Test plan

- [ ] On Pi: pull branch, reload Template Entities (Developer Tools > YAML) + reload Lovelace
- [ ] Check `sensor.weather_forecast_hourly` in Developer Tools > States - must have numeric state and `attributes.forecast` list; if empty switch template `type: hourly` -> `daily`
- [ ] Overview dashboard: chart at top of Climate section, 4 series + grey forecast band, thermostats at bottom, Measurements shows humidity only
- [ ] Climate dashboard Thermostats view: chart at top, thermostat tiles at bottom