### PR TITLE
feat: increase ApexChart history from 16h to 24h

### DIFF
--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -201,7 +201,7 @@ views:
               show: true
               show_states: true
               colorize_states: true
-            graph_span: 24h
+            graph_span: 32h
             span:
               offset: +8h
             yaxis:


### PR DESCRIPTION
This PR increases the ApexChart temperature history from 16h to 24h while maintaining 8h of future data. This change modifies the graph_span from 24h to 32h in the overview dashboard to provide a more comprehensive historical view of inside vs outside temperature comparisons.