### PR TITLE
dashboard: show 24h history in inside vs outside temp chart

### DIFF
--- a/home-assistant-amb/config/dashboard/climate.yaml
+++ b/home-assistant-amb/config/dashboard/climate.yaml
@@ -9,11 +9,11 @@ views:
           chart:
             height: 400px
         header:
-          title: Inside versus outside temperature 24h
+          title: Inside versus outside temperature
           show: true
           show_states: true
           colorize_states: true
-        graph_span: 24h
+        graph_span: 32h
         span:
           offset: +8h
         yaxis:

--- a/home-assistant-amb/config/dashboard/overview.yaml
+++ b/home-assistant-amb/config/dashboard/overview.yaml
@@ -197,11 +197,11 @@ views:
               chart:
                 height: 280px
             header:
-              title: Inside versus outside temperature 24h
+              title: Inside versus outside temperature
               show: true
               show_states: true
               colorize_states: true
-            graph_span: 24h
+            graph_span: 32h
             span:
               offset: +8h
             yaxis:


### PR DESCRIPTION
Increase `graph_span` from 24h to 32h. With the +8h future offset, this gives 24h of history instead of 16h.