### PR TITLE
feat(blueprints): brightness-aware initial dim direction for Hue wall switch

### DIFF
--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim.yaml
@@ -4,7 +4,8 @@ blueprint:
     Hue Wall Switch for Zigbee2MQTT with hold-to-dim support.
 
     Short press (release): toggle light on/off.
-    Hold: dim light brightness. First hold dims down, next hold (within 5s) dims up, alternating.
+    Hold: dim light brightness. First hold direction is determined by current brightness (down if above
+    threshold, up if at or below). Subsequent holds within the timeout window alternate direction.
 
     Supports multiple light entities per button and optional conditional light selection
     (e.g. different lights based on a binary sensor like darkness).
@@ -34,7 +35,7 @@ blueprint:
           unit_of_measurement: "%"
     direction_timeout:
       name: Direction timeout
-      description: Seconds after the last dim before direction resets to "down".
+      description: Seconds after the last dim before direction resets based on brightness.
       default: 5
       selector:
         number:
@@ -42,6 +43,19 @@ blueprint:
           max: 30
           step: 1
           unit_of_measurement: seconds
+    brightness_threshold:
+      name: Brightness threshold for initial dim direction
+      description: >
+        When dimming starts after timeout, dim down if brightness is above this
+        percentage, dim up if at or below. Falls back to "up" when brightness is
+        unavailable (float(0) = 0%).
+      default: 50
+      selector:
+        number:
+          min: 10
+          max: 90
+          step: 5
+          unit_of_measurement: "%"
 
     left_light:
       name: Left button light(s)
@@ -158,6 +172,7 @@ action:
       dim_direction_entity: "{{ dim_dir_left if side == 'left' else dim_dir_right }}"
       brightness_step_pct: !input brightness_step_pct
       direction_timeout: !input direction_timeout
+      brightness_threshold: !input brightness_threshold
       # Workaround: Some Hue wall switches occasionally emit left/right_press_release
       # instead of left/right_hold_release at the end of a hold sequence (firmware timing
       # bug when the button is released quickly after the last hold tick). Detect this by
@@ -187,7 +202,8 @@ action:
               prev_ts: "{{ parts[1] | int(0) if parts | length >= 2 else 0 }}"
               now_ts: "{{ now().timestamp() | int }}"
               timed_out: "{{ (now_ts - prev_ts) > direction_timeout }}"
-              current_dir: "{{ 'down' if timed_out else prev_dir }}"
+              current_brightness_pct: "{{ (state_attr(first_light, 'brightness') | float(0) / 255 * 100) | round(0) | int }}"
+              current_dir: "{{ ('down' if current_brightness_pct > brightness_threshold else 'up') if timed_out else prev_dir }}"
               step_value: "{{ brightness_step_pct | int if current_dir == 'up' else (brightness_step_pct | int * -1) }}"
           - repeat:
               for_each: "{{ active_lights }}"
@@ -216,7 +232,8 @@ action:
               prev_ts: "{{ parts[1] | int(0) if parts | length >= 2 else 0 }}"
               now_ts: "{{ now().timestamp() | int }}"
               timed_out: "{{ (now_ts - prev_ts) > direction_timeout }}"
-              current_dir: "{{ 'down' if timed_out else prev_dir }}"
+              current_brightness_pct: "{{ (state_attr(first_light, 'brightness') | float(0) / 255 * 100) | round(0) | int }}"
+              current_dir: "{{ ('down' if current_brightness_pct > brightness_threshold else 'up') if timed_out else prev_dir }}"
               next_dir: "{{ 'up' if current_dir == 'down' else 'down' }}"
           - action: input_text.set_value
             target:

--- a/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim_ambiance_color.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/hue_wall_switch_dim_ambiance_color.yaml
@@ -6,6 +6,7 @@ blueprint:
 
     Short press (release): toggle lights on/off (AL applies automatically via sub-groups).
     Hold: dim light brightness (disables AL adapt_brightness while dimming).
+    First hold direction is determined by current brightness (down if above threshold, up if at or below).
 
     When input_boolean_color_blocked is "on", only ambiance lights are controlled.
     This prevents the switch from interfering with wake-up light colors.
@@ -35,7 +36,7 @@ blueprint:
           unit_of_measurement: "%"
     direction_timeout:
       name: Direction timeout
-      description: Seconds after the last dim before direction resets to "down".
+      description: Seconds after the last dim before direction resets based on brightness.
       default: 5
       selector:
         number:
@@ -43,6 +44,19 @@ blueprint:
           max: 30
           step: 1
           unit_of_measurement: seconds
+    brightness_threshold:
+      name: Brightness threshold for initial dim direction
+      description: >
+        When dimming starts after timeout, dim down if brightness is above this
+        percentage, dim up if at or below. Falls back to "up" when brightness is
+        unavailable (float(0) = 0%).
+      default: 50
+      selector:
+        number:
+          min: 10
+          max: 90
+          step: 5
+          unit_of_measurement: "%"
 
     dim_direction_entity:
       name: Dim direction input_text helper
@@ -146,6 +160,7 @@ action:
       dim_direction_entity: !input dim_direction_entity
       brightness_step_pct: !input brightness_step_pct
       direction_timeout: !input direction_timeout
+      brightness_threshold: !input brightness_threshold
       # Workaround: Some Hue wall switches occasionally emit left_press_release instead
       # of left_hold_release at the end of a hold sequence (firmware timing bug that
       # occurs when the button is released very quickly after the last hold tick).
@@ -198,7 +213,8 @@ action:
               prev_ts: "{{ parts[1] | int(0) if parts | length >= 2 else 0 }}"
               now_ts: "{{ now().timestamp() | int }}"
               timed_out: "{{ (now_ts - prev_ts) > direction_timeout }}"
-              current_dir: "{{ 'down' if timed_out else prev_dir }}"
+              current_brightness_pct: "{{ (state_attr(active_lights, 'brightness') | float(0) / 255 * 100) | round(0) | int }}"
+              current_dir: "{{ ('down' if current_brightness_pct > brightness_threshold else 'up') if timed_out else prev_dir }}"
               step_value: "{{ brightness_step_pct | int if current_dir == 'up' else (brightness_step_pct | int * -1) }}"
           # Dim via the Zigbee group for consistent brightness across all lights.
           - action: light.turn_on
@@ -226,7 +242,8 @@ action:
               prev_ts: "{{ parts[1] | int(0) if parts | length >= 2 else 0 }}"
               now_ts: "{{ now().timestamp() | int }}"
               timed_out: "{{ (now_ts - prev_ts) > direction_timeout }}"
-              current_dir: "{{ 'down' if timed_out else prev_dir }}"
+              current_brightness_pct: "{{ (state_attr(active_lights, 'brightness') | float(0) / 255 * 100) | round(0) | int }}"
+              current_dir: "{{ ('down' if current_brightness_pct > brightness_threshold else 'up') if timed_out else prev_dir }}"
               next_dir: "{{ 'up' if current_dir == 'down' else 'down' }}"
           - action: input_text.set_value
             target:


### PR DESCRIPTION
## Summary

Instead of always resetting dim direction to "down" after the direction timeout, pick the initial direction based on current brightness:
- **> threshold** → dim down
- **≤ threshold** → dim up

## Changes

- Adds `brightness_threshold` input to both `hue_wall_switch_dim` and `hue_wall_switch_dim_ambiance_color` blueprints
  - Default: 50%
  - Range: 10–90% (5% steps)
- Updates `current_dir` logic in both `hold` and `hold_release` blocks
- `float(0)` fallback for unavailable brightness → 0% → dims up (safe)

## Testing

- `just test` passes