### PR TITLE
Add automation to reconnect Duux fans after startup

### DIFF
--- a/home-assistant-amb/config/automation/duux_reconnect.yaml
+++ b/home-assistant-amb/config/automation/duux_reconnect.yaml
@@ -1,0 +1,34 @@
+# duux_fan_local uses one paho-mqtt client per fan. If the initial connect()
+# fails (broker not up yet), paho never retries - the fan entity stays
+# unavailable until the config entry is reloaded. This automation handles
+# that after a reboot.
+- alias: Reconnect Duux fans after startup
+  id: duux-reconnect-after-startup
+  trigger:
+    - platform: homeassistant
+      event: start
+  action:
+    - repeat:
+        count: 3
+        sequence:
+          - delay: "00:00:30"
+          - condition: template
+            value_template: >
+              {{ is_state('fan.fan_bedroom_jc', 'unavailable')
+                 or is_state('fan.fan_study', 'unavailable') }}
+          - action: homeassistant.reload_config_entry
+            target:
+              entity_id:
+                - fan.fan_bedroom_jc
+                - fan.fan_study
+    - condition: template
+      value_template: >
+        {{ is_state('fan.fan_bedroom_jc', 'unavailable')
+           or is_state('fan.fan_study', 'unavailable') }}
+    - action: notify.mobile_app_j16
+      data:
+        title: Duux fans
+        message: >-
+          Failed to reconnect after 3 attempts.
+          Check if duux-emqx container is running.
+  mode: single

--- a/home-assistant-amb/config/automation/duux_reconnect.yaml
+++ b/home-assistant-amb/config/automation/duux_reconnect.yaml
@@ -1,34 +1,16 @@
 # duux_fan_local uses one paho-mqtt client per fan. If the initial connect()
 # fails (broker not up yet), paho never retries - the fan entity stays
-# unavailable until the config entry is reloaded. This automation handles
-# that after a reboot.
+# stuck in its default state. Unconditional reload after a delay fixes this.
 - alias: Reconnect Duux fans after startup
   id: duux-reconnect-after-startup
   trigger:
     - platform: homeassistant
       event: start
   action:
-    - repeat:
-        count: 3
-        sequence:
-          - delay: "00:00:30"
-          - condition: template
-            value_template: >
-              {{ is_state('fan.fan_bedroom_jc', 'unavailable')
-                 or is_state('fan.fan_study', 'unavailable') }}
-          - action: homeassistant.reload_config_entry
-            target:
-              entity_id:
-                - fan.fan_bedroom_jc
-                - fan.fan_study
-    - condition: template
-      value_template: >
-        {{ is_state('fan.fan_bedroom_jc', 'unavailable')
-           or is_state('fan.fan_study', 'unavailable') }}
-    - action: notify.mobile_app_j16
-      data:
-        title: Duux fans
-        message: >-
-          Failed to reconnect after 3 attempts.
-          Check if duux-emqx container is running.
+    - delay: "00:00:30"
+    - action: homeassistant.reload_config_entry
+      target:
+        entity_id:
+          - fan.fan_bedroom_jc
+          - fan.fan_study
   mode: single


### PR DESCRIPTION
## Summary

- Adds startup automation that detects unavailable Duux fan entities and reloads their config entries
- Retries up to 3 times at 30s intervals to handle slow emqx startup
- Sends notification to J16 if all attempts fail

## Context

duux_fan_local's paho-mqtt client doesn't retry if the initial `connect()` to emqx fails (broker not up yet after Pi reboot). HA marks the integration as loaded but the MQTT connection is dead - fans stay unavailable until manual restart.

## Test plan

- [ ] `just test` passes (validated locally)
- [ ] Reboot Pi, verify fans come back without manual HA restart
- [ ] Verify notification fires if emqx container is stopped