### PR TITLE
fix(ha): prevent floor avg spikes on restart

### DIFF
--- a/home-assistant-amb/config/template/climate_floor_averages.yaml
+++ b/home-assistant-amb/config/template/climate_floor_averages.yaml
@@ -12,7 +12,7 @@
       {{ [
         states('sensor.climate_living_temperature') | float(none),
         states('sensor.tado_smart_thermostat_ru1574584320_current_temperature') | float(none)
-      ] | select('is_number') | list | count > 0 }}
+      ] | select('is_number') | list | count == 2 }}
     state: >-
       {% set vals = [
         states('sensor.climate_living_temperature') | float(none),
@@ -31,7 +31,7 @@
         states('sensor.climate_laundry_temperature') | float(none),
         states('sensor.climate_bedroom_jc_temperature') | float(none),
         states('sensor.climate_bedroom_olivier_temperature') | float(none)
-      ] | select('is_number') | list | count > 0 }}
+      ] | select('is_number') | list | count == 4 }}
     state: >-
       {% set vals = [
         states('sensor.climate_bathroom_temperature') | float(none),
@@ -55,7 +55,7 @@
         states('sensor.climate_utility_temperature') | float(none),
         states('sensor.climate_bedroom_duco_temperature') | float(none),
         states('sensor.climate_study_temperature') | float(none)
-      ] | select('is_number') | list | count > 0 }}
+      ] | select('is_number') | list | count == 3 }}
     state: >-
       {% set vals = [
         states('sensor.climate_utility_temperature') | float(none),
@@ -73,7 +73,7 @@
       {{ [
         states('sensor.climate_living_humidity') | float(none),
         states('sensor.tado_smart_thermostat_ru1574584320_current_humidity') | float(none)
-      ] | select('is_number') | list | count > 0 }}
+      ] | select('is_number') | list | count == 2 }}
     state: >-
       {% set vals = [
         states('sensor.climate_living_humidity') | float(none),
@@ -92,7 +92,7 @@
         states('sensor.climate_laundry_humidity') | float(none),
         states('sensor.climate_bedroom_jc_humidity') | float(none),
         states('sensor.climate_bedroom_olivier_humidity') | float(none)
-      ] | select('is_number') | list | count > 0 }}
+      ] | select('is_number') | list | count == 4 }}
     state: >-
       {% set vals = [
         states('sensor.climate_bathroom_humidity') | float(none),
@@ -113,7 +113,7 @@
         states('sensor.climate_utility_humidity') | float(none),
         states('sensor.climate_bedroom_duco_humidity') | float(none),
         states('sensor.climate_study_humidity') | float(none)
-      ] | select('is_number') | list | count > 0 }}
+      ] | select('is_number') | list | count == 3 }}
     state: >-
       {% set vals = [
         states('sensor.climate_utility_humidity') | float(none),


### PR DESCRIPTION
During HA restart, sensors come online sequentially. The floor average sensors were publishing partial averages (e.g. 1 of 4 sensors available), causing visible spikes in graphs.

**Fix:** Change `availability` condition from `count > 0` to `count == N` for each floor average sensor. If any source sensor is unavailable, the average reports `unavailable` instead of a skewed value. HA graphs render this as a straight line (no spike).

**Affected sensors:** Ground floor (2), First floor (4), Second floor (3) — both temperature and humidity.