### PR TITLE
chore(ha): upgrade home-assistant base image to 2026.7.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ just build              # Build Docker image with custom components
 just test               # Validate Home Assistant configuration (requires Docker)
 ```
 
-The build process creates a custom Docker image based on `ghcr.io/home-assistant/home-assistant:2026.5.2` with baked-in custom components:
+The build process creates a custom Docker image based on `ghcr.io/home-assistant/home-assistant:2026.7.0` with baked-in custom components:
 - **adaptive-lighting**: Dynamic light color/brightness adjustment
 - **duux_fan_local**: Local control of Duux fans via the `duux-emqx/` broker
 

--- a/home-assistant-amb/docker/Dockerfile
+++ b/home-assistant-amb/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/home-assistant/home-assistant:2026.5.2
+FROM ghcr.io/home-assistant/home-assistant:2026.7.0
 
 ARG ADAPTIVE_LIGHTING_VERSION=1.30.1
 


### PR DESCRIPTION
Upgrade `home-assistant-amb` from Home Assistant 2026.5.2 to 2026.7.0.

**Changes:**
- `home-assistant-amb/docker/Dockerfile` — base image tag 2026.5.2 → 2026.7.0
- `CLAUDE.md` — doc reference updated

**Validation:**
- `just build` — pass
- `just test` — pass (config validation clean)

**Deploy:** Run `docker compose up -d --build` on the Pi in `home-assistant-amb/` after merge.