### PR TITLE
chore(zigbee2mqtt): upgrade to 2.12.1

### DIFF
--- a/zigbee2mqtt/docker-compose.yml
+++ b/zigbee2mqtt/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   zigbee2mqtt:
     container_name: zigbee2mqtt
     restart: unless-stopped
-    image: koenkk/zigbee2mqtt:2.10.1
+    image: koenkk/zigbee2mqtt:2.12.1
     volumes:
       - ./zigbee2mqtt-data:/app/data
       - /run/udev:/run/udev:ro


### PR DESCRIPTION
## Summary
Upgrade Zigbee2MQTT to 2.12.1.

## Changes
- Updated image tag in zigbee2mqtt/docker-compose.yml

## Validation
- docker compose config passes
- No other references to old tag in repo

## Post-deploy
Run on Pi: cd zigbee2mqtt && docker compose up -d
Verify frontend on port 8002, broker connected, coordinator online, HA discovery intact.
