### PR TITLE
feat(ha): show kWh used in washing machine done notification

### DIFF
--- a/home-assistant-amb/config/automation/washing_machine.yaml
+++ b/home-assistant-amb/config/automation/washing_machine.yaml
@@ -10,8 +10,25 @@
     - service: notify.notify
       data:
         title: Washing machine
-        message: Done
+        message: >-
+          Done. Used {{ ([ (states('sensor.plug_washing_machine_energy') | float(0)) -
+          (states('input_number.washing_machine_cycle_start_energy') | float(0)), 0 ]
+          | max) | round(2) }} kWh
         data:
           push:
             sound: "washing-machine-done.wav"
+  mode: restart
+
+- alias: Track washing machine cycle start energy
+  id: washing-machine-cycle-start-energy
+  trigger:
+    - platform: state
+      entity_id: sensor.washing_machine_state
+      from: 'off'
+  action:
+    - service: input_number.set_value
+      target:
+        entity_id: input_number.washing_machine_cycle_start_energy
+      data:
+        value: "{{ states('sensor.plug_washing_machine_energy') | float(0) }}"
   mode: restart

--- a/home-assistant-amb/config/input_number.yaml
+++ b/home-assistant-amb/config/input_number.yaml
@@ -86,3 +86,13 @@ fan_bedroom_jc_end_pct:
   step: 1
   unit_of_measurement: "%"
   icon: "mdi:fan"
+
+washing_machine_cycle_start_energy:
+  name: Washing Machine Cycle Start Energy
+  initial: 0
+  min: 0
+  max: 100000
+  step: 0.01
+  unit_of_measurement: "kWh"
+  icon: "mdi:lightning-bolt"
+  mode: box


### PR DESCRIPTION
## Summary

The "Alert washing machine done" notification now shows how many kWh the completed wash cycle used.

## How it works

- New `input_number.washing_machine_cycle_start_energy` helper stores the energy meter reading at cycle start
- New "Track washing machine cycle start energy" automation captures the reading when `sensor.washing_machine_state` leaves `off`
- The existing "done" automation computes the delta and includes it in the notification: `Done. Used 0.5 kWh`

## Files changed

- `home-assistant-amb/config/input_number.yaml` — added `washing_machine_cycle_start_energy` helper
- `home-assistant-amb/config/automation/washing_machine.yaml` — added cycle-start automation + updated notification message template

## Notes

- The helper persists across HA restarts
- If deployed while a cycle is mid-run, that one in-flight cycle will show an inflated value. All subsequent cycles are accurate.
