### PR TITLE
feat(ha): window temperature alerts per floor

### DIFF
--- a/docs/plans/2026-07-13-window-temperature-alerts.md
+++ b/docs/plans/2026-07-13-window-temperature-alerts.md
@@ -1,0 +1,476 @@
+# Window Temperature Alerts per Floor Implementation Plan
+
+**Source spec**: `docs/specs/001-window-temperature-alerts.md`
+
+**Goal:** Send J16 one-time per-floor window close/open guidance on forecast-hot days.
+
+**Architecture:** Add unavailable-safe comparison template sensors plus restored helpers for daily activation and delivery state. A single blueprint handles stable crossover detection and notifications for a floor; one scheduled automation calculates the local-day forecast maximum and instantiates that blueprint three times.
+
+**Tech Stack:** Home Assistant 2026.7.0 YAML configuration, Jinja2 templates, Home Assistant automation blueprints, OpenWeatherMap forecast data, mobile-app notifications.
+
+## Global Constraints
+
+- Activation runs exactly at `08:00` local time. No startup or late retry is permitted.
+- Qualify only when highest valid *future* hourly forecast entry whose local date is today is strictly greater than `25°C`.
+- Use `sensor.openweathermap_temperature`, `sensor.weather_forecast_hourly`, and existing ground/first/second floor average sensors. Do not alter dashboard/chart/floor-average definitions or add attic.
+- Comparison sensors must be `unavailable` unless both temperatures are numeric. Never default a missing temperature to zero.
+- Keep activation and six sent flags persistent across restarts. Do not set `initial` on sent flags.
+- Every close/open relation requires five uninterrupted minutes; an initial cooler relation must not create an open alert.
+- Each qualifying day permits one activation, at most one close, and at most one open notification per floor. Close and open flags are independent.
+- Notification target is `notify.mobile_app_j16`; notification data URL is `/dashboard-climate/inside-vs-outside`.
+- YAML uses two-space indentation. Run `just test` from `home-assistant-amb` and `pre-commit run --all-files` from repository root.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `home-assistant-amb/config/template/window_heat_alerts.yaml` | Derive `warmer`, `equal`, or `cooler` per floor only from valid numeric values. |
+| `home-assistant-amb/config/input_datetime.yaml` | Persist date making guidance active. |
+| `home-assistant-amb/config/input_boolean.yaml` | Persist independent per-floor close/open delivery flags. |
+| `home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml` | Reusable floor-level five-minute crossover, activation reconciliation, notification, and one-shot behavior. |
+| `home-assistant-amb/config/automation/window_heat_alerts.yaml` | 08:00 forecast evaluation and three blueprint instances. |
+
+No automated Home Assistant YAML unit-test harness exists in this repository. Each task uses `just test` for schema/config validation; final task executes exact manual behavior matrix from source spec.
+
+### Task 1: Add comparison sensors and persistent state
+**Complexity:** Medium
+
+**Files:**
+- Create: `home-assistant-amb/config/template/window_heat_alerts.yaml`
+- Modify: `home-assistant-amb/config/input_datetime.yaml`
+- Modify: `home-assistant-amb/config/input_boolean.yaml`
+
+**Interfaces:**
+- Consumes: `sensor.openweathermap_temperature`; `sensor.climate_{ground,first,second}_floor_temperature`.
+- Produces: `sensor.window_heat_{ground,first,second}_floor_comparison` with state `warmer|equal|cooler|unavailable`; `input_datetime.window_heat_alert_activation_date`; six `input_boolean.window_heat_*_{close,open}_sent` helpers.
+
+- [ ] **Step 1: Create unavailable-safe comparison sensors**
+
+Create `home-assistant-amb/config/template/window_heat_alerts.yaml`:
+
+```yaml
+- sensor:
+  - name: Window Heat Ground Floor Comparison
+    unique_id: window_heat_ground_floor_comparison
+    availability: >-
+      {{ [
+        states('sensor.openweathermap_temperature') | float(none),
+        states('sensor.climate_ground_floor_temperature') | float(none)
+      ] | select('is_number') | list | count == 2 }}
+    state: >-
+      {% set outside = states('sensor.openweathermap_temperature') | float(none) %}
+      {% set inside = states('sensor.climate_ground_floor_temperature') | float(none) %}
+      {% if outside > inside %}warmer{% elif outside < inside %}cooler{% else %}equal{% endif %}
+
+  - name: Window Heat First Floor Comparison
+    unique_id: window_heat_first_floor_comparison
+    availability: >-
+      {{ [
+        states('sensor.openweathermap_temperature') | float(none),
+        states('sensor.climate_first_floor_temperature') | float(none)
+      ] | select('is_number') | list | count == 2 }}
+    state: >-
+      {% set outside = states('sensor.openweathermap_temperature') | float(none) %}
+      {% set inside = states('sensor.climate_first_floor_temperature') | float(none) %}
+      {% if outside > inside %}warmer{% elif outside < inside %}cooler{% else %}equal{% endif %}
+
+  - name: Window Heat Second Floor Comparison
+    unique_id: window_heat_second_floor_comparison
+    availability: >-
+      {{ [
+        states('sensor.openweathermap_temperature') | float(none),
+        states('sensor.climate_second_floor_temperature') | float(none)
+      ] | select('is_number') | list | count == 2 }}
+    state: >-
+      {% set outside = states('sensor.openweathermap_temperature') | float(none) %}
+      {% set inside = states('sensor.climate_second_floor_temperature') | float(none) %}
+      {% if outside > inside %}warmer{% elif outside < inside %}cooler{% else %}equal{% endif %}
+```
+
+- [ ] **Step 2: Add restored helpers**
+
+Append to `home-assistant-amb/config/input_datetime.yaml`:
+
+```yaml
+window_heat_alert_activation_date:
+  name: Window Heat Alert Activation Date
+  has_date: true
+  has_time: false
+```
+
+Append to `home-assistant-amb/config/input_boolean.yaml`. Do not add `initial` to any of these:
+
+```yaml
+window_heat_ground_floor_close_sent:
+  name: Window Heat Ground Floor Close Sent
+window_heat_ground_floor_open_sent:
+  name: Window Heat Ground Floor Open Sent
+window_heat_first_floor_close_sent:
+  name: Window Heat First Floor Close Sent
+window_heat_first_floor_open_sent:
+  name: Window Heat First Floor Open Sent
+window_heat_second_floor_close_sent:
+  name: Window Heat Second Floor Close Sent
+window_heat_second_floor_open_sent:
+  name: Window Heat Second Floor Open Sent
+```
+
+- [ ] **Step 3: Validate configuration**
+
+Run: `cd home-assistant-amb && just test`
+
+Expected: no output and exit code `0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add home-assistant-amb/config/template/window_heat_alerts.yaml \
+  home-assistant-amb/config/input_datetime.yaml \
+  home-assistant-amb/config/input_boolean.yaml
+git commit -m "feat(ha): add window heat alert state"
+```
+
+### Task 2: Create reusable per-floor alert blueprint
+**Complexity:** Medium
+
+**Files:**
+- Create: `home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml`
+
+**Interfaces:**
+- Consumes: comparison sensor state (`warmer|equal|cooler`), numeric indoor/outdoor sensor states, activation helper date, and two sent flags from Task 1.
+- Produces: one J16 close notification after a valid/continuous warmer relation and one open notification after a valid/continuous cooler transition. It calls `input_boolean.turn_on` only after notification service action.
+
+- [ ] **Step 1: Create blueprint**
+
+Create `home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml`:
+
+```yaml
+blueprint:
+  name: Window heat alert
+  description: Send one close and one open window alert for an active floor.
+  domain: automation
+  input:
+    floor_name:
+      name: Floor name
+      selector:
+        text: {}
+    comparison_sensor:
+      name: Comparison sensor
+      selector:
+        entity:
+          domain: sensor
+    indoor_temperature_sensor:
+      name: Indoor temperature sensor
+      selector:
+        entity:
+          domain: sensor
+          device_class: temperature
+    outdoor_temperature_sensor:
+      name: Outdoor temperature sensor
+      selector:
+        entity:
+          domain: sensor
+          device_class: temperature
+    activation_date_helper:
+      name: Activation date helper
+      selector:
+        entity:
+          domain: input_datetime
+    close_sent_helper:
+      name: Close sent helper
+      selector:
+        entity:
+          domain: input_boolean
+    open_sent_helper:
+      name: Open sent helper
+      selector:
+        entity:
+          domain: input_boolean
+
+mode: restart
+
+variables:
+  floor_name: !input floor_name
+  comparison_sensor: !input comparison_sensor
+  indoor_temperature_sensor: !input indoor_temperature_sensor
+  outdoor_temperature_sensor: !input outdoor_temperature_sensor
+  activation_date_helper: !input activation_date_helper
+  close_sent_helper: !input close_sent_helper
+  open_sent_helper: !input open_sent_helper
+
+trigger:
+  - id: close_crossing
+    platform: state
+    entity_id: !input comparison_sensor
+    to: warmer
+    for: "00:05:00"
+  - id: close_activation
+    platform: state
+    entity_id: !input activation_date_helper
+  - id: open_crossing
+    platform: state
+    entity_id: !input comparison_sensor
+    to: cooler
+    for: "00:05:00"
+
+condition: []
+
+action:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: close_activation
+          - condition: template
+            value_template: "{{ trigger.to_state.state == now().date() | string }}"
+          - condition: state
+            entity_id: !input comparison_sensor
+            state: warmer
+        sequence:
+          - delay: "00:05:00"
+          - condition: template
+            value_template: >-
+              {{ states(activation_date_helper) == now().date() | string and
+                 states(comparison_sensor) == 'warmer' and
+                 is_state(close_sent_helper, 'off') }}
+          - service: notify.mobile_app_j16
+            data:
+              title: "Close windows - {{ floor_name }}"
+              message: >-
+                Outside has been warmer than the {{ floor_name | lower }} for 5 minutes.
+                Outside: {{ states(outdoor_temperature_sensor) | float | round(1) }}°C.
+                {{ floor_name }}: {{ states(indoor_temperature_sensor) | float | round(1) }}°C.
+              data:
+                url: /dashboard-climate/inside-vs-outside
+          - service: input_boolean.turn_on
+            target:
+              entity_id: !input close_sent_helper
+      - conditions:
+          - condition: trigger
+            id: close_crossing
+          - condition: template
+            value_template: >-
+              {{ trigger.from_state is not none and
+                 trigger.from_state.state in ['warmer', 'equal', 'cooler'] and
+                 states(activation_date_helper) == now().date() | string and
+                 is_state(close_sent_helper, 'off') }}
+        sequence:
+          - service: notify.mobile_app_j16
+            data:
+              title: "Close windows - {{ floor_name }}"
+              message: >-
+                Outside has been warmer than the {{ floor_name | lower }} for 5 minutes.
+                Outside: {{ states(outdoor_temperature_sensor) | float | round(1) }}°C.
+                {{ floor_name }}: {{ states(indoor_temperature_sensor) | float | round(1) }}°C.
+              data:
+                url: /dashboard-climate/inside-vs-outside
+          - service: input_boolean.turn_on
+            target:
+              entity_id: !input close_sent_helper
+      - conditions:
+          - condition: trigger
+            id: open_crossing
+          - condition: template
+            value_template: >-
+              {{ trigger.from_state is not none and
+                 trigger.from_state.state in ['warmer', 'equal'] and
+                 states(activation_date_helper) == now().date() | string and
+                 is_state(open_sent_helper, 'off') }}
+        sequence:
+          - service: notify.mobile_app_j16
+            data:
+              title: "Open windows - {{ floor_name }}"
+              message: >-
+                Outside has been cooler than the {{ floor_name | lower }} for 5 minutes.
+                Outside: {{ states(outdoor_temperature_sensor) | float | round(1) }}°C.
+                {{ floor_name }}: {{ states(indoor_temperature_sensor) | float | round(1) }}°C.
+              data:
+                url: /dashboard-climate/inside-vs-outside
+          - service: input_boolean.turn_on
+            target:
+              entity_id: !input open_sent_helper
+```
+
+- [ ] **Step 2: Validate configuration**
+
+Run: `cd home-assistant-amb && just test`
+
+Expected: no output and exit code `0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
+```
+
+### Task 3: Schedule forecast activation and configure floors
+**Complexity:** Medium
+
+**Files:**
+- Create: `home-assistant-amb/config/automation/window_heat_alerts.yaml`
+
+**Interfaces:**
+- Consumes: Task 1 helpers/sensors, Task 2 blueprint, and `sensor.weather_forecast_hourly` attribute `forecast` entries with `datetime` and `temperature` fields.
+- Produces: daily activation notification and three independent blueprint automations for Ground floor, First floor, and Second floor.
+
+- [ ] **Step 1: Add activation automation and blueprint instances**
+
+Create `home-assistant-amb/config/automation/window_heat_alerts.yaml`:
+
+```yaml
+- id: window_heat_alert_daily_activation
+  alias: Window heat alert daily activation
+  trigger:
+    - platform: time
+      at: "08:00:00"
+  variables:
+    today: "{{ now().date() | string }}"
+    forecast_max: >-
+      {% set ns = namespace(maximum=none) %}
+      {% for item in state_attr('sensor.weather_forecast_hourly', 'forecast') | default([], true) %}
+        {% set timestamp = as_datetime(item.datetime, default=none) %}
+        {% set temperature = item.temperature | float(none) %}
+        {% if timestamp is not none and temperature is number and timestamp > now() and as_local(timestamp).date() == now().date() %}
+          {% if ns.maximum is none or temperature > ns.maximum %}
+            {% set ns.maximum = temperature %}
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+      {{ ns.maximum }}
+  action:
+    - service: input_boolean.turn_off
+      target:
+        entity_id:
+          - input_boolean.window_heat_ground_floor_close_sent
+          - input_boolean.window_heat_ground_floor_open_sent
+          - input_boolean.window_heat_first_floor_close_sent
+          - input_boolean.window_heat_first_floor_open_sent
+          - input_boolean.window_heat_second_floor_close_sent
+          - input_boolean.window_heat_second_floor_open_sent
+    - service: input_datetime.set_datetime
+      target:
+        entity_id: input_datetime.window_heat_alert_activation_date
+      data:
+        date: "{{ (now().date() - timedelta(days=1)) | string }}"
+    - choose:
+        - conditions:
+            - condition: template
+              value_template: "{{ forecast_max | float(none) is not none and forecast_max | float > 25 }}"
+          sequence:
+            - service: input_datetime.set_datetime
+              target:
+                entity_id: input_datetime.window_heat_alert_activation_date
+              data:
+                date: "{{ today }}"
+            - service: notify.mobile_app_j16
+              data:
+                title: Window alerts activated
+                message: >-
+                  Today's remaining forecast reaches {{ forecast_max | float | round(1) }}°C.
+                  Window guidance is active for all floors.
+                data:
+                  url: /dashboard-climate/inside-vs-outside
+  mode: single
+
+- id: window_heat_alert_ground_floor
+  alias: Window heat alert - Ground floor
+  use_blueprint:
+    path: custom/window_heat_alert.yaml
+    input:
+      floor_name: Ground floor
+      comparison_sensor: sensor.window_heat_ground_floor_comparison
+      indoor_temperature_sensor: sensor.climate_ground_floor_temperature
+      outdoor_temperature_sensor: sensor.openweathermap_temperature
+      activation_date_helper: input_datetime.window_heat_alert_activation_date
+      close_sent_helper: input_boolean.window_heat_ground_floor_close_sent
+      open_sent_helper: input_boolean.window_heat_ground_floor_open_sent
+
+- id: window_heat_alert_first_floor
+  alias: Window heat alert - First floor
+  use_blueprint:
+    path: custom/window_heat_alert.yaml
+    input:
+      floor_name: First floor
+      comparison_sensor: sensor.window_heat_first_floor_comparison
+      indoor_temperature_sensor: sensor.climate_first_floor_temperature
+      outdoor_temperature_sensor: sensor.openweathermap_temperature
+      activation_date_helper: input_datetime.window_heat_alert_activation_date
+      close_sent_helper: input_boolean.window_heat_first_floor_close_sent
+      open_sent_helper: input_boolean.window_heat_first_floor_open_sent
+
+- id: window_heat_alert_second_floor
+  alias: Window heat alert - Second floor
+  use_blueprint:
+    path: custom/window_heat_alert.yaml
+    input:
+      floor_name: Second floor
+      comparison_sensor: sensor.window_heat_second_floor_comparison
+      indoor_temperature_sensor: sensor.climate_second_floor_temperature
+      outdoor_temperature_sensor: sensor.openweathermap_temperature
+      activation_date_helper: input_datetime.window_heat_alert_activation_date
+      close_sent_helper: input_boolean.window_heat_second_floor_close_sent
+      open_sent_helper: input_boolean.window_heat_second_floor_open_sent
+```
+
+- [ ] **Step 2: Validate configuration**
+
+Run: `cd home-assistant-amb && just test`
+
+Expected: no output and exit code `0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add home-assistant-amb/config/automation/window_heat_alerts.yaml
+```
+
+### Task 4: Run repository checks and verify live behavior
+**Complexity:** Low
+
+**Files:** None
+
+**Interfaces:**
+- Consumes: completed Tasks 1-3.
+- Produces: validated YAML and live confirmation that all fourteen source-spec manual cases behave correctly.
+
+- [ ] **Step 1: Run final validation**
+
+```bash
+cd home-assistant-amb && just test
+cd .. && pre-commit run --all-files
+```
+
+Expected: `just test` has no output and exit code `0`; all pre-commit hooks pass.
+
+- [ ] **Step 2: Deploy YAML-only configuration**
+
+On Raspberry Pi in `home-assistant-amb`:
+
+```bash
+git pull
+```
+
+Reload Template Entities, Automations, and Helpers in Developer Tools -> YAML, or restart Home Assistant. Do not run Docker rebuild: image is unchanged.
+
+- [ ] **Step 3: Verify manual behavior matrix**
+
+In Developer Tools, use temporary sensor states / automation traces and confirm:
+
+1. Forecast maximum `25` produces no activation; `25.1` produces one notification and today activation date.
+2. Missing, empty, malformed, past-only, or nonnumeric forecast data produces no activation or notification.
+3. Each comparison sensor is unavailable for unavailable/nonnumeric source values; valid pairs yield correct `warmer`, `equal`, or `cooler` state.
+4. A warmer transition under five minutes sends nothing; five uninterrupted minutes sends one close notification for correct floor.
+5. A cooler transition under five minutes sends nothing; five uninterrupted minutes sends one open notification for correct floor, even with close flag off.
+6. Initial warmer activation sends close only after five minutes; initial cooler activation sends no open notification.
+7. Repeated same-direction transitions do not send twice after relevant flag is on; three simultaneous floor crossings deliver three separate notifications.
+8. Restart after a sent notification retains activation/flag state and does not duplicate; restart during timer requires fresh five minutes.
+9. On next 08:00, all six flags reset whether forecast qualifies or not; next qualifying day can send all alerts again.
+
+- [ ] **Step 4: Commit formatting corrections only if hooks changed files**
+
+```bash
+git status --short
+```
+
+Expected: commit only if `pre-commit` modified files. Otherwise make no extra commit.

--- a/docs/specs/001-window-temperature-alerts.md
+++ b/docs/specs/001-window-temperature-alerts.md
@@ -1,0 +1,268 @@
+# Window Temperature Alerts per Floor
+
+## Status
+
+Approved design specification.
+
+## Summary
+
+Add a Home Assistant notification system that recommends closing or opening windows independently for ground, first, and second floors on forecast hot days. System activates at 08:00 only when highest remaining hourly OpenWeatherMap forecast temperature for current local day is strictly above 25°C.
+
+On active days, J16 receives one activation confirmation plus at most one close and one open alert per floor. Alerts use existing outside temperature and floor-average temperature entities shown in Inside versus Outside chart.
+
+## Goals
+
+- Activate window guidance only on qualifying hot days.
+- Confirm activation once at 08:00.
+- Detect inside/outside temperature crossover independently per floor.
+- Send separate close and open notifications for each floor.
+- Require crossover condition to remain stable for five minutes.
+- Prevent duplicate same-day notifications despite temperature fluctuations.
+- Preserve activation and one-shot state across Home Assistant restarts.
+- Reuse per-floor logic through custom automation blueprint.
+
+## Non-goals
+
+- Detect actual window state.
+- Automatically open or close windows.
+- Retry activation after 08:00.
+- Send inactive-status notifications on cool days.
+- Add dashboard controls or user-configurable thresholds/times.
+- Change chart, floor-average sensors, or floor room membership.
+- Include attic in second-floor average.
+
+## Existing entities
+
+Outdoor source:
+
+- `sensor.openweathermap_temperature`
+- `sensor.weather_forecast_hourly`, using `forecast` attribute
+
+Indoor sources:
+
+- `sensor.climate_ground_floor_temperature`
+- `sensor.climate_first_floor_temperature`
+- `sensor.climate_second_floor_temperature`
+
+Notification target:
+
+- `notify.mobile_app_j16`
+
+Notification link:
+
+- `/dashboard-climate/inside-vs-outside`
+
+## Proposed components
+
+### Per-floor comparison template sensors
+
+Add `home-assistant-amb/config/template/window_heat_alerts.yaml` with one sensor per floor. Each sensor compares current outdoor temperature with corresponding floor average and has one of these states:
+
+- `warmer` when outside temperature is strictly greater than floor temperature
+- `equal` when temperatures are equal
+- `cooler` when outside temperature is strictly less than floor temperature
+
+Sensors must be unavailable unless both source states are numeric. They must not substitute zero or another default for missing temperature data.
+
+Suggested entity IDs:
+
+- `sensor.window_heat_ground_floor_comparison`
+- `sensor.window_heat_first_floor_comparison`
+- `sensor.window_heat_second_floor_comparison`
+
+### Persistent helpers
+
+Add one date-only helper to `home-assistant-amb/config/input_datetime.yaml`:
+
+- `input_datetime.window_heat_alert_activation_date`
+
+System is active exactly when helper date equals current Home Assistant local date.
+
+Add six helpers to `home-assistant-amb/config/input_boolean.yaml`:
+
+- `input_boolean.window_heat_ground_floor_close_sent`
+- `input_boolean.window_heat_ground_floor_open_sent`
+- `input_boolean.window_heat_first_floor_close_sent`
+- `input_boolean.window_heat_first_floor_open_sent`
+- `input_boolean.window_heat_second_floor_close_sent`
+- `input_boolean.window_heat_second_floor_open_sent`
+
+Do not give sent flags an `initial` value. Home Assistant must restore them after restart.
+
+### Reusable floor blueprint
+
+Add `home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml`.
+
+Blueprint inputs:
+
+- Human-readable floor name
+- Comparison sensor
+- Indoor floor temperature sensor
+- Outdoor temperature sensor
+- Activation-date helper
+- Close-sent helper
+- Open-sent helper
+
+Blueprint owns all per-floor crossover, five-minute confirmation, notification, and one-shot behavior. Notification target can remain fixed to J16 because this feature has one selected destination.
+
+### Automation configuration
+
+Add `home-assistant-amb/config/automation/window_heat_alerts.yaml` containing:
+
+1. One daily activation automation.
+2. Three concise blueprint instances, one for each floor.
+
+Only floor names and entity mappings should differ between blueprint instances.
+
+## Functional behavior
+
+### Daily activation
+
+At exactly 08:00 local time:
+
+1. Reset all six sent flags.
+2. Ensure activation date does not indicate current day before forecast evaluation.
+3. Read `forecast` from `sensor.weather_forecast_hourly`.
+4. Keep forecast entries whose timestamps:
+   - are in future relative to evaluation time, and
+   - resolve to current Home Assistant local date.
+5. Find maximum valid temperature among remaining entries.
+6. Activate only when maximum is strictly greater than 25°C.
+
+When qualifying:
+
+- Set activation date to current local date.
+- Send exactly one J16 notification.
+- Include forecast maximum and explain that per-floor window alerts are active.
+- Link notification to existing Inside versus Outside chart.
+
+When not qualifying, when no current-day future entries exist, or when forecast data is unavailable/malformed:
+
+- Keep system inactive.
+- Send no notification.
+- Do not retry later that day.
+
+If Home Assistant is offline at 08:00, activation is missed for that day. Startup must not perform delayed activation.
+
+### Close alert
+
+For each floor independently:
+
+- Trigger when comparison enters `warmer` from a valid prior comparison state and remains `warmer` continuously for five minutes.
+- Require activation date to equal current local date.
+- Require floor close-sent helper to be off.
+- Send one separate J16 close notification for that floor.
+- Include floor name plus current outside and floor temperatures.
+- Link to existing chart.
+- Turn on floor close-sent helper after notification action.
+
+If system activates while floor comparison is already `warmer`, blueprint must treat activation as a candidate close condition. It waits five minutes, verifies condition remained warmer, then sends close alert if not already sent.
+
+### Open alert
+
+For each floor independently:
+
+- Trigger when comparison enters `cooler` from a valid prior comparison state and remains `cooler` continuously for five minutes.
+- Require activation date to equal current local date.
+- Require floor open-sent helper to be off.
+- Send one separate J16 open notification for that floor.
+- Include floor name plus current outside and floor temperatures.
+- Link to existing chart.
+- Turn on floor open-sent helper after notification action.
+
+Open alert must not require close-sent helper to be on. A valid cooler crossover may alert even when no close notification was sent earlier.
+
+Initial `cooler` state at activation must not produce morning open alert. Open requires a subsequent valid transition into cooler state.
+
+### Duplicate prevention
+
+- Each sent flag is independent.
+- Once a floor close flag is on, later warmer crossings that day do not notify.
+- Once a floor open flag is on, later cooler crossings that day do not notify.
+- Flags reset at next 08:00 evaluation, whether next day qualifies or not.
+- Three floor automations must run independently so simultaneous crossovers cannot suppress another floor's alert.
+
+Maximum notifications on one qualifying day:
+
+- One activation confirmation
+- Three close notifications
+- Three open notifications
+
+## Notification copy
+
+Exact wording may be adjusted during implementation, but intent must remain clear.
+
+Activation example:
+
+- Title: `Window alerts activated`
+- Message: `Today's remaining forecast reaches 27.3°C. Window guidance is active for all floors.`
+
+Close example:
+
+- Title: `Close windows - First floor`
+- Message: `Outside has been warmer than the first floor for 5 minutes. Outside: 24.8°C. First floor: 24.5°C.`
+
+Open example:
+
+- Title: `Open windows - First floor`
+- Message: `Outside has been cooler than the first floor for 5 minutes. Outside: 23.7°C. First floor: 24.1°C.`
+
+## State and restart behavior
+
+- Activation date and sent flags restore across restart.
+- Restart must not clear already-sent state or cause duplicate same-day notifications.
+- Invalid startup transitions from `unknown` or `unavailable` must not count as open crossover.
+- Five-minute `for` timers do not need durable elapsed-time persistence. After restart/reload, implementation may require a fresh stable period or next valid transition, but must never send immediately from stale/unknown data.
+- Existing warmer condition may be safely reconciled for unsent close guidance because closing is actionable whenever active day resumes. Existing cooler condition must not be interpreted as open crossover without valid transition context.
+
+## Error handling
+
+- Forecast parsing must tolerate missing attribute, empty list, invalid timestamps, and nonnumeric temperatures.
+- Temperature comparisons must expose unavailable state when either source is unavailable or nonnumeric.
+- Do not activate or notify from partial/defaulted values.
+- Notification service failure must be visible through Home Assistant automation trace/log. No retry subsystem is required.
+
+## Validation
+
+Required repository validation:
+
+```bash
+cd home-assistant-amb
+just test
+```
+
+Also run:
+
+```bash
+pre-commit run --all-files
+```
+
+Manual behavior matrix:
+
+1. Remaining forecast maximum exactly 25°C: inactive, no notification.
+2. Remaining forecast maximum above 25°C: active, one confirmation.
+3. Forecast unavailable or empty at 08:00: inactive, no notification.
+4. Warmer state under five minutes: no close alert.
+5. Warmer state for five minutes: correct floor close alert.
+6. Repeated warmer crossings: no second close alert that day.
+7. Cooler state under five minutes: no open alert.
+8. Cooler state for five minutes: correct floor open alert.
+9. Open crossover with close-sent off: open alert still occurs.
+10. Initial cooler state at activation: no open alert.
+11. Three near-simultaneous floor crossovers: three separate notifications.
+12. Source temperature unavailable: no comparison alert.
+13. Restart after sent alert: no duplicate.
+14. Next qualifying day: flags reset and all alerts can occur again.
+
+## Acceptance criteria
+
+- At 08:00, system activates only if highest remaining hourly forecast for current local day is greater than 25°C.
+- J16 receives one activation confirmation only on qualifying days.
+- Each floor independently sends no more than one close and one open alert per active day.
+- Every crossover alert requires five continuous minutes in target relation.
+- Temperature fluctuations cannot create duplicate same-day alerts.
+- Open alerts do not depend on close notification state.
+- Ground, first, and second floor alerts use existing floor-average entities.
+- Missing or invalid source data cannot produce false alerts.
+- Existing chart and floor averaging remain unchanged.
+- Home Assistant configuration validation and pre-commit checks pass.

--- a/home-assistant-amb/config/automation/window_heat_alerts.yaml
+++ b/home-assistant-amb/config/automation/window_heat_alerts.yaml
@@ -1,0 +1,92 @@
+- id: window_heat_alert_daily_activation
+  alias: Window heat alert daily activation
+  trigger:
+    - platform: time
+      at: "08:00:00"
+  variables:
+    today: "{{ now().date() | string }}"
+    forecast_max: >-
+      {% set ns = namespace(maximum=none) %}
+      {% for item in state_attr('sensor.weather_forecast_hourly', 'forecast') | default([], true) %}
+        {% set timestamp = as_datetime(item.datetime, default=none) %}
+        {% set temperature = item.temperature | float(none) %}
+        {% if timestamp is not none and temperature is number and timestamp > now() and as_local(timestamp).date() == now().date() %}
+          {% if ns.maximum is none or temperature > ns.maximum %}
+            {% set ns.maximum = temperature %}
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+      {{ ns.maximum }}
+  action:
+    - service: input_boolean.turn_off
+      target:
+        entity_id:
+          - input_boolean.window_heat_ground_floor_close_sent
+          - input_boolean.window_heat_ground_floor_open_sent
+          - input_boolean.window_heat_first_floor_close_sent
+          - input_boolean.window_heat_first_floor_open_sent
+          - input_boolean.window_heat_second_floor_close_sent
+          - input_boolean.window_heat_second_floor_open_sent
+    - service: input_datetime.set_datetime
+      target:
+        entity_id: input_datetime.window_heat_alert_activation_date
+      data:
+        date: "{{ (now().date() - timedelta(days=1)) | string }}"
+    - choose:
+        - conditions:
+            - condition: template
+              value_template: "{{ forecast_max | float(none) is not none and forecast_max | float > 25 }}"
+          sequence:
+            - service: input_datetime.set_datetime
+              target:
+                entity_id: input_datetime.window_heat_alert_activation_date
+              data:
+                date: "{{ today }}"
+            - service: notify.mobile_app_j16
+              data:
+                title: Window alerts activated
+                message: >-
+                  Today's remaining forecast reaches {{ forecast_max | float | round(1) }}°C.
+                  Window guidance is active for all floors.
+                data:
+                  url: /dashboard-climate/inside-vs-outside
+  mode: single
+
+- id: window_heat_alert_ground_floor
+  alias: Window heat alert - Ground floor
+  use_blueprint:
+    path: custom/window_heat_alert.yaml
+    input:
+      floor_name: Ground floor
+      comparison_sensor: sensor.window_heat_ground_floor_comparison
+      indoor_temperature_sensor: sensor.climate_ground_floor_temperature
+      outdoor_temperature_sensor: sensor.openweathermap_temperature
+      activation_date_helper: input_datetime.window_heat_alert_activation_date
+      close_sent_helper: input_boolean.window_heat_ground_floor_close_sent
+      open_sent_helper: input_boolean.window_heat_ground_floor_open_sent
+
+- id: window_heat_alert_first_floor
+  alias: Window heat alert - First floor
+  use_blueprint:
+    path: custom/window_heat_alert.yaml
+    input:
+      floor_name: First floor
+      comparison_sensor: sensor.window_heat_first_floor_comparison
+      indoor_temperature_sensor: sensor.climate_first_floor_temperature
+      outdoor_temperature_sensor: sensor.openweathermap_temperature
+      activation_date_helper: input_datetime.window_heat_alert_activation_date
+      close_sent_helper: input_boolean.window_heat_first_floor_close_sent
+      open_sent_helper: input_boolean.window_heat_first_floor_open_sent
+
+- id: window_heat_alert_second_floor
+  alias: Window heat alert - Second floor
+  use_blueprint:
+    path: custom/window_heat_alert.yaml
+    input:
+      floor_name: Second floor
+      comparison_sensor: sensor.window_heat_second_floor_comparison
+      indoor_temperature_sensor: sensor.climate_second_floor_temperature
+      outdoor_temperature_sensor: sensor.openweathermap_temperature
+      activation_date_helper: input_datetime.window_heat_alert_activation_date
+      close_sent_helper: input_boolean.window_heat_second_floor_close_sent
+      open_sent_helper: input_boolean.window_heat_second_floor_open_sent

--- a/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
@@ -79,10 +79,16 @@ action:
             entity_id: !input comparison_sensor
             state: warmer
         sequence:
-          - delay: "00:05:00"
+          - wait_for_trigger:
+              - platform: state
+                entity_id: !input comparison_sensor
+                not_to: warmer
+            timeout: "00:05:00"
+            continue_on_timeout: true
           - condition: template
             value_template: >-
-              {{ states(activation_date_helper) == now().date() | string and
+              {{ wait.trigger is none and
+                 states(activation_date_helper) == now().date() | string and
                  states(comparison_sensor) == 'warmer' and
                  is_state(close_sent_helper, 'off') }}
           - service: notify.mobile_app_j16
@@ -105,7 +111,8 @@ action:
               {{ trigger.from_state is not none and
                  trigger.from_state.state in ['warmer', 'equal', 'cooler'] and
                  states(activation_date_helper) == now().date() | string and
-                 is_state(close_sent_helper, 'off') }}
+                 is_state(close_sent_helper, 'off') and
+                 trigger.to_state.last_changed >= (states[activation_date_helper].last_changed if states[activation_date_helper] else trigger.to_state.last_changed) }}
         sequence:
           - service: notify.mobile_app_j16
             data:
@@ -127,7 +134,8 @@ action:
               {{ trigger.from_state is not none and
                  trigger.from_state.state in ['warmer', 'equal'] and
                  states(activation_date_helper) == now().date() | string and
-                 is_state(open_sent_helper, 'off') }}
+                 is_state(open_sent_helper, 'off') and
+                 trigger.to_state.last_changed >= (states[activation_date_helper].last_changed if states[activation_date_helper] else trigger.to_state.last_changed) }}
         sequence:
           - service: notify.mobile_app_j16
             data:

--- a/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
@@ -40,7 +40,8 @@ blueprint:
         entity:
           domain: input_boolean
 
-mode: restart
+mode: queued
+max: 10
 
 variables:
   floor_name: !input floor_name

--- a/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
@@ -1,0 +1,143 @@
+blueprint:
+  name: Window heat alert
+  description: Send one close and one open window alert for an active floor.
+  domain: automation
+  input:
+    floor_name:
+      name: Floor name
+      selector:
+        text: {}
+    comparison_sensor:
+      name: Comparison sensor
+      selector:
+        entity:
+          domain: sensor
+    indoor_temperature_sensor:
+      name: Indoor temperature sensor
+      selector:
+        entity:
+          domain: sensor
+          device_class: temperature
+    outdoor_temperature_sensor:
+      name: Outdoor temperature sensor
+      selector:
+        entity:
+          domain: sensor
+          device_class: temperature
+    activation_date_helper:
+      name: Activation date helper
+      selector:
+        entity:
+          domain: input_datetime
+    close_sent_helper:
+      name: Close sent helper
+      selector:
+        entity:
+          domain: input_boolean
+    open_sent_helper:
+      name: Open sent helper
+      selector:
+        entity:
+          domain: input_boolean
+
+mode: restart
+
+variables:
+  floor_name: !input floor_name
+  comparison_sensor: !input comparison_sensor
+  indoor_temperature_sensor: !input indoor_temperature_sensor
+  outdoor_temperature_sensor: !input outdoor_temperature_sensor
+  activation_date_helper: !input activation_date_helper
+  close_sent_helper: !input close_sent_helper
+  open_sent_helper: !input open_sent_helper
+
+trigger:
+  - id: close_crossing
+    platform: state
+    entity_id: !input comparison_sensor
+    to: warmer
+    for: "00:05:00"
+  - id: close_activation
+    platform: state
+    entity_id: !input activation_date_helper
+  - id: open_crossing
+    platform: state
+    entity_id: !input comparison_sensor
+    to: cooler
+    for: "00:05:00"
+
+condition: []
+
+action:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: close_activation
+          - condition: template
+            value_template: "{{ trigger.to_state.state == now().date() | string }}"
+          - condition: state
+            entity_id: !input comparison_sensor
+            state: warmer
+        sequence:
+          - delay: "00:05:00"
+          - condition: template
+            value_template: >-
+              {{ states(activation_date_helper) == now().date() | string and
+                 states(comparison_sensor) == 'warmer' and
+                 is_state(close_sent_helper, 'off') }}
+          - service: notify.mobile_app_j16
+            data:
+              title: "Close windows - {{ floor_name }}"
+              message: >-
+                Outside has been warmer than the {{ floor_name | lower }} for 5 minutes.
+                Outside: {{ states(outdoor_temperature_sensor) | float | round(1) }}°C.
+                {{ floor_name }}: {{ states(indoor_temperature_sensor) | float | round(1) }}°C.
+              data:
+                url: /dashboard-climate/inside-vs-outside
+          - service: input_boolean.turn_on
+            target:
+              entity_id: !input close_sent_helper
+      - conditions:
+          - condition: trigger
+            id: close_crossing
+          - condition: template
+            value_template: >-
+              {{ trigger.from_state is not none and
+                 trigger.from_state.state in ['warmer', 'equal', 'cooler'] and
+                 states(activation_date_helper) == now().date() | string and
+                 is_state(close_sent_helper, 'off') }}
+        sequence:
+          - service: notify.mobile_app_j16
+            data:
+              title: "Close windows - {{ floor_name }}"
+              message: >-
+                Outside has been warmer than the {{ floor_name | lower }} for 5 minutes.
+                Outside: {{ states(outdoor_temperature_sensor) | float | round(1) }}°C.
+                {{ floor_name }}: {{ states(indoor_temperature_sensor) | float | round(1) }}°C.
+              data:
+                url: /dashboard-climate/inside-vs-outside
+          - service: input_boolean.turn_on
+            target:
+              entity_id: !input close_sent_helper
+      - conditions:
+          - condition: trigger
+            id: open_crossing
+          - condition: template
+            value_template: >-
+              {{ trigger.from_state is not none and
+                 trigger.from_state.state in ['warmer', 'equal'] and
+                 states(activation_date_helper) == now().date() | string and
+                 is_state(open_sent_helper, 'off') }}
+        sequence:
+          - service: notify.mobile_app_j16
+            data:
+              title: "Open windows - {{ floor_name }}"
+              message: >-
+                Outside has been cooler than the {{ floor_name | lower }} for 5 minutes.
+                Outside: {{ states(outdoor_temperature_sensor) | float | round(1) }}°C.
+                {{ floor_name }}: {{ states(indoor_temperature_sensor) | float | round(1) }}°C.
+              data:
+                url: /dashboard-climate/inside-vs-outside
+          - service: input_boolean.turn_on
+            target:
+              entity_id: !input open_sent_helper

--- a/home-assistant-amb/config/input_boolean.yaml
+++ b/home-assistant-amb/config/input_boolean.yaml
@@ -27,3 +27,16 @@ wake_up_lights_kids_cycle_in_progress:
   name: Wake Up Lights Kids Cycle In Progress
   icon: mdi:alarm-note
   initial: false
+
+window_heat_ground_floor_close_sent:
+  name: Window Heat Ground Floor Close Sent
+window_heat_ground_floor_open_sent:
+  name: Window Heat Ground Floor Open Sent
+window_heat_first_floor_close_sent:
+  name: Window Heat First Floor Close Sent
+window_heat_first_floor_open_sent:
+  name: Window Heat First Floor Open Sent
+window_heat_second_floor_close_sent:
+  name: Window Heat Second Floor Close Sent
+window_heat_second_floor_open_sent:
+  name: Window Heat Second Floor Open Sent

--- a/home-assistant-amb/config/input_datetime.yaml
+++ b/home-assistant-amb/config/input_datetime.yaml
@@ -4,3 +4,8 @@ wake_up_light_kids_start_orange:
   has_date: false
   has_time: true
   initial: "06:50"
+
+window_heat_alert_activation_date:
+  name: Window Heat Alert Activation Date
+  has_date: true
+  has_time: false

--- a/home-assistant-amb/config/template/window_heat_alerts.yaml
+++ b/home-assistant-amb/config/template/window_heat_alerts.yaml
@@ -1,0 +1,36 @@
+- sensor:
+  - name: Window Heat Ground Floor Comparison
+    unique_id: window_heat_ground_floor_comparison
+    availability: >-
+      {{ [
+        states('sensor.openweathermap_temperature') | float(none),
+        states('sensor.climate_ground_floor_temperature') | float(none)
+      ] | select('is_number') | list | count == 2 }}
+    state: >-
+      {% set outside = states('sensor.openweathermap_temperature') | float(none) %}
+      {% set inside = states('sensor.climate_ground_floor_temperature') | float(none) %}
+      {% if outside > inside %}warmer{% elif outside < inside %}cooler{% else %}equal{% endif %}
+
+  - name: Window Heat First Floor Comparison
+    unique_id: window_heat_first_floor_comparison
+    availability: >-
+      {{ [
+        states('sensor.openweathermap_temperature') | float(none),
+        states('sensor.climate_first_floor_temperature') | float(none)
+      ] | select('is_number') | list | count == 2 }}
+    state: >-
+      {% set outside = states('sensor.openweathermap_temperature') | float(none) %}
+      {% set inside = states('sensor.climate_first_floor_temperature') | float(none) %}
+      {% if outside > inside %}warmer{% elif outside < inside %}cooler{% else %}equal{% endif %}
+
+  - name: Window Heat Second Floor Comparison
+    unique_id: window_heat_second_floor_comparison
+    availability: >-
+      {{ [
+        states('sensor.openweathermap_temperature') | float(none),
+        states('sensor.climate_second_floor_temperature') | float(none)
+      ] | select('is_number') | list | count == 2 }}
+    state: >-
+      {% set outside = states('sensor.openweathermap_temperature') | float(none) %}
+      {% set inside = states('sensor.climate_second_floor_temperature') | float(none) %}
+      {% if outside > inside %}warmer{% elif outside < inside %}cooler{% else %}equal{% endif %}


### PR DESCRIPTION
## Summary

Adds per-floor window open/close guidance notifications on forecast-hot days, per docs/specs/001-window-temperature-alerts.md and docs/plans/2026-07-13-window-temperature-alerts.md.

- Adds unavailable-safe comparison template sensors (sensor.window_heat_{ground,first,second}_floor_comparison) comparing outdoor temperature to each floor's average.
- Adds persistent helpers: input_datetime.window_heat_alert_activation_date and six input_boolean.window_heat_*_{close,open}_sent flags (no initial, so they restore across restart).
- Adds reusable blueprint custom/window_heat_alert.yaml implementing five-minute stable crossover detection, one-shot close/open notifications per floor, and activation reconciliation (handles an already-warmer state at activation).
- Adds automation/window_heat_alerts.yaml: one 08:00 activation automation that computes today's remaining forecast maximum and three blueprint instances (ground/first/second floor).

## Notes

- Notifications go to notify.mobile_app_j16, linking to /dashboard-climate/inside-vs-outside.
- Activation only fires once at 08:00 (no startup/late retry) when the highest remaining hourly forecast for today is strictly above 25C.
- During review, two blueprint race conditions were found and fixed:
  - Activation-branch delay now uses wait_for_trigger to require a genuinely uninterrupted 5-minute warmer window instead of only checking the state after a blind delay.
  - Crossing triggers now reject stale pre-activation timers via a last_changed guard.
  - Automation mode changed from restart to queued (max 10) so a stale/rejected trigger can no longer cancel an in-flight activation reconciliation wait.

## Validation

- just test (from home-assistant-amb): pass
- pre-commit run --all-files: pass
- Manual live behavior matrix (14 cases in the spec) still needs to be run on the live Raspberry Pi after deploy - not possible from this sandbox.