### PR TITLE
feat(ha): per-floor window open/close alerts on hot days

### DIFF
--- a/home-assistant-amb/config/automation/window_alerts.yaml
+++ b/home-assistant-amb/config/automation/window_alerts.yaml
@@ -1,0 +1,199 @@
+- alias: Window alerts morning check
+  id: window_alerts_morning_check
+  trigger:
+    - platform: time
+      at: "08:00:00"
+  variables:
+    forecast_today_max: >-
+      {% set fc = state_attr('sensor.weather_forecast_hourly', 'forecast') | default([]) %}
+      {% set ns = namespace(mx = -100) %}
+      {% for f in fc %}
+        {% set f_date = as_datetime(f.datetime) | as_local %}
+        {% if f_date.date() == now().date() and f.temperature | float(-100) > ns.mx %}
+          {% set ns.mx = f.temperature | float(-100) %}
+        {% endif %}
+      {% endfor %}
+      {{ ns.mx }}
+  action:
+    - choose:
+        - conditions:
+            - "{{ forecast_today_max | float(-100) > states('input_number.window_alert_hot_day_threshold') | float }}"
+          sequence:
+            - service: input_boolean.turn_on
+              target:
+                entity_id: input_boolean.window_alerts_armed
+            - service: input_boolean.turn_off
+              target:
+                entity_id:
+                  - input_boolean.windows_closed_ground_floor
+                  - input_boolean.windows_closed_first_floor
+                  - input_boolean.windows_closed_second_floor
+            - service: notify.mobile_app_j16
+              data:
+                title: Window alerts armed
+                message: >-
+                  Hot day ahead (forecast max {{ forecast_today_max | round(1) }}°C). You'll get
+                  a nudge per floor when it's time to close and later open your windows.
+                data:
+                  url: /dashboard-climate/inside-vs-outside
+      default:
+        - service: input_boolean.turn_off
+          target:
+            entity_id: input_boolean.window_alerts_armed
+  mode: single
+
+- alias: Window alert ground floor
+  id: window_alert_ground_floor
+  trigger:
+    - platform: state
+      entity_id:
+        - sensor.openweathermap_temperature
+        - sensor.climate_ground_floor_temperature
+  variables:
+    outside: "{{ states('sensor.openweathermap_temperature') | float(none) }}"
+    inside: "{{ states('sensor.climate_ground_floor_temperature') | float(none) }}"
+    margin: "{{ states('input_number.window_alert_hysteresis') | float(0.5) }}"
+    floor_name: ground floor
+    closed_flag: input_boolean.windows_closed_ground_floor
+  condition:
+    - condition: state
+      entity_id: input_boolean.window_alerts_armed
+      state: "on"
+    - "{{ outside is not none and inside is not none }}"
+  action:
+    - choose:
+        - conditions:
+            - "{{ is_state(closed_flag, 'off') }}"
+            - "{{ outside > inside + margin }}"
+          sequence:
+            - service: input_boolean.turn_on
+              target:
+                entity_id: "{{ closed_flag }}"
+            - service: notify.mobile_app_j16
+              data:
+                title: "Close windows — {{ floor_name }}"
+                message: >-
+                  Outside ({{ outside | round(1) }}°C) is now warmer than the {{ floor_name }}
+                  ({{ inside | round(1) }}°C). Close the windows.
+                data:
+                  url: /dashboard-climate/inside-vs-outside
+        - conditions:
+            - "{{ is_state(closed_flag, 'on') }}"
+            - "{{ outside < inside - margin }}"
+          sequence:
+            - service: input_boolean.turn_off
+              target:
+                entity_id: "{{ closed_flag }}"
+            - service: notify.mobile_app_j16
+              data:
+                title: "Open windows — {{ floor_name }}"
+                message: >-
+                  Outside ({{ outside | round(1) }}°C) has dropped below the {{ floor_name }}
+                  ({{ inside | round(1) }}°C). Open the windows.
+                data:
+                  url: /dashboard-climate/inside-vs-outside
+  mode: single
+
+- alias: Window alert first floor
+  id: window_alert_first_floor
+  trigger:
+    - platform: state
+      entity_id:
+        - sensor.openweathermap_temperature
+        - sensor.climate_first_floor_temperature
+  variables:
+    outside: "{{ states('sensor.openweathermap_temperature') | float(none) }}"
+    inside: "{{ states('sensor.climate_first_floor_temperature') | float(none) }}"
+    margin: "{{ states('input_number.window_alert_hysteresis') | float(0.5) }}"
+    floor_name: first floor
+    closed_flag: input_boolean.windows_closed_first_floor
+  condition:
+    - condition: state
+      entity_id: input_boolean.window_alerts_armed
+      state: "on"
+    - "{{ outside is not none and inside is not none }}"
+  action:
+    - choose:
+        - conditions:
+            - "{{ is_state(closed_flag, 'off') }}"
+            - "{{ outside > inside + margin }}"
+          sequence:
+            - service: input_boolean.turn_on
+              target:
+                entity_id: "{{ closed_flag }}"
+            - service: notify.mobile_app_j16
+              data:
+                title: "Close windows — {{ floor_name }}"
+                message: >-
+                  Outside ({{ outside | round(1) }}°C) is now warmer than the {{ floor_name }}
+                  ({{ inside | round(1) }}°C). Close the windows.
+                data:
+                  url: /dashboard-climate/inside-vs-outside
+        - conditions:
+            - "{{ is_state(closed_flag, 'on') }}"
+            - "{{ outside < inside - margin }}"
+          sequence:
+            - service: input_boolean.turn_off
+              target:
+                entity_id: "{{ closed_flag }}"
+            - service: notify.mobile_app_j16
+              data:
+                title: "Open windows — {{ floor_name }}"
+                message: >-
+                  Outside ({{ outside | round(1) }}°C) has dropped below the {{ floor_name }}
+                  ({{ inside | round(1) }}°C). Open the windows.
+                data:
+                  url: /dashboard-climate/inside-vs-outside
+  mode: single
+
+- alias: Window alert second floor
+  id: window_alert_second_floor
+  trigger:
+    - platform: state
+      entity_id:
+        - sensor.openweathermap_temperature
+        - sensor.climate_second_floor_temperature
+  variables:
+    outside: "{{ states('sensor.openweathermap_temperature') | float(none) }}"
+    inside: "{{ states('sensor.climate_second_floor_temperature') | float(none) }}"
+    margin: "{{ states('input_number.window_alert_hysteresis') | float(0.5) }}"
+    floor_name: second floor
+    closed_flag: input_boolean.windows_closed_second_floor
+  condition:
+    - condition: state
+      entity_id: input_boolean.window_alerts_armed
+      state: "on"
+    - "{{ outside is not none and inside is not none }}"
+  action:
+    - choose:
+        - conditions:
+            - "{{ is_state(closed_flag, 'off') }}"
+            - "{{ outside > inside + margin }}"
+          sequence:
+            - service: input_boolean.turn_on
+              target:
+                entity_id: "{{ closed_flag }}"
+            - service: notify.mobile_app_j16
+              data:
+                title: "Close windows — {{ floor_name }}"
+                message: >-
+                  Outside ({{ outside | round(1) }}°C) is now warmer than the {{ floor_name }}
+                  ({{ inside | round(1) }}°C). Close the windows.
+                data:
+                  url: /dashboard-climate/inside-vs-outside
+        - conditions:
+            - "{{ is_state(closed_flag, 'on') }}"
+            - "{{ outside < inside - margin }}"
+          sequence:
+            - service: input_boolean.turn_off
+              target:
+                entity_id: "{{ closed_flag }}"
+            - service: notify.mobile_app_j16
+              data:
+                title: "Open windows — {{ floor_name }}"
+                message: >-
+                  Outside ({{ outside | round(1) }}°C) has dropped below the {{ floor_name }}
+                  ({{ inside | round(1) }}°C). Open the windows.
+                data:
+                  url: /dashboard-climate/inside-vs-outside
+  mode: single

--- a/home-assistant-amb/config/input_boolean.yaml
+++ b/home-assistant-amb/config/input_boolean.yaml
@@ -27,3 +27,21 @@ wake_up_lights_kids_cycle_in_progress:
   name: Wake Up Lights Kids Cycle In Progress
   icon: mdi:alarm-note
   initial: false
+
+window_alerts_armed:
+  name: Window Alerts Armed
+  icon: mdi:window-open-variant
+  initial: false
+
+windows_closed_ground_floor:
+  name: Windows Closed Ground Floor
+  icon: mdi:window-closed
+  initial: false
+windows_closed_first_floor:
+  name: Windows Closed First Floor
+  icon: mdi:window-closed
+  initial: false
+windows_closed_second_floor:
+  name: Windows Closed Second Floor
+  icon: mdi:window-closed
+  initial: false

--- a/home-assistant-amb/config/input_number.yaml
+++ b/home-assistant-amb/config/input_number.yaml
@@ -86,3 +86,21 @@ fan_bedroom_jc_end_pct:
   step: 1
   unit_of_measurement: "%"
   icon: "mdi:fan"
+
+window_alert_hot_day_threshold:
+  name: Window Alert Hot Day Threshold
+  initial: 25
+  min: 20
+  max: 35
+  step: 0.5
+  unit_of_measurement: "°C"
+  icon: "mdi:thermometer-high"
+
+window_alert_hysteresis:
+  name: Window Alert Hysteresis
+  initial: 0.5
+  min: 0
+  max: 3
+  step: 0.1
+  unit_of_measurement: "°C"
+  icon: "mdi:arrow-expand-vertical"


### PR DESCRIPTION
## Summary
- Morning check at 08:00 arms window alerts when today's forecast max exceeds a threshold (default 25°C, tunable via `input_number.window_alert_hot_day_threshold`), sending a confirmation push on hot days
- Per floor (ground/first/second), sends a one-time "close windows" push when outside rises above that floor's average temp, and a one-time "open windows" push when it later drops back below - with a hysteresis margin (`input_number.window_alert_hysteresis`, default 0.5°C) to avoid repeat alerts from minor fluctuations
- New helpers: `input_boolean.window_alerts_armed` + one `windows_closed_*_floor` flag per floor, reset each morning

## Test plan
- [x] `just test` passes
- [x] pre-commit clean
- [ ] Validate the forecast-max template in Developer Tools → Template against live `sensor.weather_forecast_hourly` data
- [ ] Manually trigger morning check with a lowered threshold, confirm the armed push + flag resets
- [ ] Nudge `sensor.openweathermap_temperature` above/below a floor's inside temp in Developer Tools → States, confirm single close/open push per crossing and no repeats on minor wiggles