### PR TITLE
feat(ha): add emojis to notification titles

### DIFF
--- a/home-assistant-amb/config/automation/fridge.yaml
+++ b/home-assistant-amb/config/automation/fridge.yaml
@@ -7,9 +7,9 @@
   action:
     - service: notify.mobile_app_j16
       data:
-        title: Fridge
+        title: 🌡️ Fridge
         message: >-
-          Fridge temperature is high.
+          Fridge temperature is high!
           Measured {{ states('sensor.climate_fridge_temperature') | round(1) }}°C
         data:
           url: /dashboard-power/appliances

--- a/home-assistant-amb/config/automation/power.yaml
+++ b/home-assistant-amb/config/automation/power.yaml
@@ -11,7 +11,7 @@
   action:
     - service: notify.mobile_app_j16
       data:
-        title: Electricity overload warning
+        title: ⚡ Electricity overload warning
         message: >
           One of the phases is over 25A.
           L1 (droger, schuur): {{ states('sensor.electricity_meter_current_phase_l1') | round }}A,

--- a/home-assistant-amb/config/automation/washing_machine.yaml
+++ b/home-assistant-amb/config/automation/washing_machine.yaml
@@ -9,8 +9,8 @@
   action:
     - service: notify.notify
       data:
-        title: Washing machine
-        message: Done
+        title: 🧺 Washing machine
+        message: Done ✅
         data:
           push:
             sound: "washing-machine-done.wav"

--- a/home-assistant-amb/config/automation/window_heat_alerts.yaml
+++ b/home-assistant-amb/config/automation/window_heat_alerts.yaml
@@ -44,7 +44,7 @@
                 date: "{{ today }}"
             - service: notify.mobile_app_j16
               data:
-                title: Window alerts activated
+                title: ☀️ Window alerts activated
                 message: >-
                   Today's remaining forecast reaches {{ forecast_max | float | round(1) }}°C.
                   Window guidance is active for all floors.

--- a/home-assistant-amb/config/automation/zigbee_device_offline.yaml
+++ b/home-assistant-amb/config/automation/zigbee_device_offline.yaml
@@ -1,7 +1,7 @@
 # Relies on template sensor in sensor/zigbee_device_offline.yaml
 
 - id: zigbee_device_offline_daily_reminder
-  alias: &ref_alias_reminder Zigbee device offline daily reminder
+  alias: Zigbee device offline daily reminder
   trigger:
     - platform: time
       at: "20:00:00"
@@ -13,12 +13,17 @@
   action:
     - service: notify.mobile_app_j16
       data:
-        title: *ref_alias_reminder
+        title: >-
+          {% if states(templ_sensor) == 'No devices offline!' %}
+            ✅ Zigbee devices online
+          {% else %}
+            ⚠️ Zigbee device offline daily reminder
+          {% endif %}
         message: "{{ states(templ_sensor) }}"
   mode: restart
 
 - id: zigbee_device_offline_status_change
-  alias: &ref_alias_change Zigbee device offline status change
+  alias: Zigbee device offline status change
   trigger:
     - platform: state
       entity_id: *templ_sensor
@@ -33,6 +38,11 @@
     - delay: "00:00:30"
     - service: notify.mobile_app_j16
       data:
-        title: *ref_alias_change
+        title: >-
+          {% if states(templ_sensor) == 'No devices offline!' %}
+            ✅ All Zigbee devices online
+          {% else %}
+            ⚠️ Zigbee device offline status change
+          {% endif %}
         message: "{{ states(templ_sensor) }}"
   mode: restart

--- a/home-assistant-amb/config/blueprints/automation/custom/heating_needed_alert.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/heating_needed_alert.yaml
@@ -20,7 +20,7 @@ blueprint:
       default: 16
       selector:
         number:
-          min: 15  # Condenstation issues may appear below 15 degrees, don't go any lower than this.
+          min: 15
           max: 18
           step: 0.5
 
@@ -45,5 +45,5 @@ variables:
 action:
   - service: notify.notify
     data:
-      title: "Heating needed in {{ room_name }}"
+      title: "❄️ Heating needed in {{ room_name }}"
       message: "The temperature has dropped below {{ threshold }}℃."

--- a/home-assistant-amb/config/blueprints/automation/custom/water_leak.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/water_leak.yaml
@@ -34,7 +34,7 @@ variables:
 action:
   - service: notify.notify
     data:
-      title: WATER LEAK!
+      title: "🚨 WATER LEAK!"
       message: >
         Water leak detected by {{ states[water_leak_sensor].name }}.
         {{ 'Turning off ' ~ states[device_to_turn_off].name ~ '.' if device_to_turn_off else 'No device configured to turn off.' }}

--- a/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
@@ -94,7 +94,7 @@ action:
                  is_state(close_sent_helper, 'off') }}
           - service: notify.mobile_app_j16
             data:
-              title: "Close windows - {{ floor_name }}"
+              title: "☀️ Close windows - {{ floor_name }}"
               message: >-
                 Outside has been warmer than the {{ floor_name | lower }} for 5 minutes.
                 Outside: {{ states(outdoor_temperature_sensor) | float | round(1) }}°C.
@@ -117,7 +117,7 @@ action:
         sequence:
           - service: notify.mobile_app_j16
             data:
-              title: "Close windows - {{ floor_name }}"
+              title: "☀️ Close windows - {{ floor_name }}"
               message: >-
                 Outside has been warmer than the {{ floor_name | lower }} for 5 minutes.
                 Outside: {{ states(outdoor_temperature_sensor) | float | round(1) }}°C.
@@ -140,7 +140,7 @@ action:
         sequence:
           - service: notify.mobile_app_j16
             data:
-              title: "Open windows - {{ floor_name }}"
+              title: "🍃 Open windows - {{ floor_name }}"
               message: >-
                 Outside has been cooler than the {{ floor_name | lower }} for 5 minutes.
                 Outside: {{ states(outdoor_temperature_sensor) | float | round(1) }}°C.


### PR DESCRIPTION
## Summary

Add distinctive emojis to all notification titles so their type is identifiable at a glance in the notification tray.

| Notification | Emoji |
|---|---|
| Zigbee device offline (warning) | ⚠️ |
| Zigbee device offline (all online) | ✅ |
| Washing machine done | 🧺 |
| Fridge temp high | 🌡️ |
| Window alerts activated | ☀️ |
| Close windows | ☀️ |
| Open windows | 🍃 |
| Electricity overload | ⚡ |
| Heating needed | ❄️ |
| Water leak | 🚨 |

The Zigbee notification title uses a Jinja template to switch between ⚠️ and ✅ depending on whether devices are offline.

## Validation

- `just test` passed with no errors
- Pre-commit hooks passed (YAML check, end-of-file, trailing whitespace)