### PR TITLE
fix(ha): simplify window alert messages, add emojis

### DIFF
--- a/home-assistant-amb/config/automation/window_heat_alerts.yaml
+++ b/home-assistant-amb/config/automation/window_heat_alerts.yaml
@@ -59,7 +59,6 @@
     input:
       floor_name: Ground floor
       comparison_sensor: sensor.window_heat_ground_floor_comparison
-      indoor_temperature_sensor: sensor.climate_ground_floor_temperature
       outdoor_temperature_sensor: sensor.openweathermap_temperature
       activation_date_helper: input_datetime.window_heat_alert_activation_date
       close_sent_helper: input_boolean.window_heat_ground_floor_close_sent
@@ -72,7 +71,6 @@
     input:
       floor_name: First floor
       comparison_sensor: sensor.window_heat_first_floor_comparison
-      indoor_temperature_sensor: sensor.climate_first_floor_temperature
       outdoor_temperature_sensor: sensor.openweathermap_temperature
       activation_date_helper: input_datetime.window_heat_alert_activation_date
       close_sent_helper: input_boolean.window_heat_first_floor_close_sent
@@ -85,7 +83,6 @@
     input:
       floor_name: Second floor
       comparison_sensor: sensor.window_heat_second_floor_comparison
-      indoor_temperature_sensor: sensor.climate_second_floor_temperature
       outdoor_temperature_sensor: sensor.openweathermap_temperature
       activation_date_helper: input_datetime.window_heat_alert_activation_date
       close_sent_helper: input_boolean.window_heat_second_floor_close_sent

--- a/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
@@ -12,12 +12,6 @@ blueprint:
       selector:
         entity:
           domain: sensor
-    indoor_temperature_sensor:
-      name: Indoor temperature sensor
-      selector:
-        entity:
-          domain: sensor
-          device_class: temperature
     outdoor_temperature_sensor:
       name: Outdoor temperature sensor
       selector:
@@ -46,7 +40,6 @@ max: 10
 variables:
   floor_name: !input floor_name
   comparison_sensor: !input comparison_sensor
-  indoor_temperature_sensor: !input indoor_temperature_sensor
   outdoor_temperature_sensor: !input outdoor_temperature_sensor
   activation_date_helper: !input activation_date_helper
   close_sent_helper: !input close_sent_helper
@@ -94,11 +87,9 @@ action:
                  is_state(close_sent_helper, 'off') }}
           - service: notify.mobile_app_j16
             data:
-              title: "Close windows - {{ floor_name }}"
+              title: "🔥 Close windows - {{ floor_name }}"
               message: >-
-                Outside has been warmer than the {{ floor_name | lower }} for 5 minutes.
-                Outside: {{ states(outdoor_temperature_sensor) | float | round(1) }}°C.
-                {{ floor_name }}: {{ states(indoor_temperature_sensor) | float | round(1) }}°C.
+                It's warmer outside now ({{ states(outdoor_temperature_sensor) | float | round(1) }}°C), so keeping the windows closed will help keep this floor cool.
               data:
                 url: /dashboard-climate/inside-vs-outside
           - service: input_boolean.turn_on
@@ -117,11 +108,9 @@ action:
         sequence:
           - service: notify.mobile_app_j16
             data:
-              title: "Close windows - {{ floor_name }}"
+              title: "🔥 Close windows - {{ floor_name }}"
               message: >-
-                Outside has been warmer than the {{ floor_name | lower }} for 5 minutes.
-                Outside: {{ states(outdoor_temperature_sensor) | float | round(1) }}°C.
-                {{ floor_name }}: {{ states(indoor_temperature_sensor) | float | round(1) }}°C.
+                It's warmer outside now ({{ states(outdoor_temperature_sensor) | float | round(1) }}°C), so keeping the windows closed will help keep this floor cool.
               data:
                 url: /dashboard-climate/inside-vs-outside
           - service: input_boolean.turn_on
@@ -140,11 +129,9 @@ action:
         sequence:
           - service: notify.mobile_app_j16
             data:
-              title: "Open windows - {{ floor_name }}"
+              title: "🌬️ Open windows - {{ floor_name }}"
               message: >-
-                Outside has been cooler than the {{ floor_name | lower }} for 5 minutes.
-                Outside: {{ states(outdoor_temperature_sensor) | float | round(1) }}°C.
-                {{ floor_name }}: {{ states(indoor_temperature_sensor) | float | round(1) }}°C.
+                It's cooler outside now ({{ states(outdoor_temperature_sensor) | float | round(1) }}°C), so opening the windows can help cool this floor.
               data:
                 url: /dashboard-climate/inside-vs-outside
           - service: input_boolean.turn_on


### PR DESCRIPTION

## Changes

- **Close windows notification:** `🔥 Close windows - {floor}` — "It's warmer outside now (X°C), so keeping the windows closed will help keep this floor cool."
- **Open windows notification:** `🌬️ Open windows - {floor}` — "It's cooler outside now (X°C), so opening the windows can help cool this floor."
- Removed "for 5 minutes" implementation detail
- Show only outdoor temperature (indoor is nearly identical when alert fires)
- Removed now-unused `indoor_temperature_sensor` blueprint input from blueprint and all three automation instances

## Validation

- `pre-commit` (YAML check, end-of-file, trailing whitespace): passed
- `just test` (Home Assistant config validation): passed
