### PR TITLE
Add clickAction and action buttons to mobile notifications

### DIFF
--- a/home-assistant-amb/config/automation/fridge.yaml
+++ b/home-assistant-amb/config/automation/fridge.yaml
@@ -12,7 +12,7 @@
           Fridge temperature is high!
           Measured {{ states('sensor.climate_fridge_temperature') | round(1) }}°C
         data:
-          clickAction: /dashboard-power/appliances
+          url: /dashboard-power/appliances
           actions:
             - action: "URI"
               title: "Open Appliances"

--- a/home-assistant-amb/config/automation/fridge.yaml
+++ b/home-assistant-amb/config/automation/fridge.yaml
@@ -12,5 +12,9 @@
           Fridge temperature is high!
           Measured {{ states('sensor.climate_fridge_temperature') | round(1) }}°C
         data:
-          url: /dashboard-power/appliances
+          clickAction: /dashboard-power/appliances
+          actions:
+            - action: "URI"
+              title: "Open Appliances"
+              uri: "/dashboard-power/appliances"
   mode: single

--- a/home-assistant-amb/config/automation/power.yaml
+++ b/home-assistant-amb/config/automation/power.yaml
@@ -16,3 +16,9 @@
           One of the phases is over 25A.
           L1 (droger, schuur): {{ states('sensor.electricity_meter_current_phase_l1') | round }}A,
           L2 (WM, oven): {{ states('sensor.electricity_meter_current_phase_l2') | round }}A
+        data:
+          clickAction: /dashboard-power/overview
+          actions:
+            - action: "URI"
+              title: "Open Power Dashboard"
+              uri: "/dashboard-power/overview"

--- a/home-assistant-amb/config/automation/power.yaml
+++ b/home-assistant-amb/config/automation/power.yaml
@@ -17,7 +17,7 @@
           L1 (droger, schuur): {{ states('sensor.electricity_meter_current_phase_l1') | round }}A,
           L2 (WM, oven): {{ states('sensor.electricity_meter_current_phase_l2') | round }}A
         data:
-          clickAction: /dashboard-power/overview
+          url: /dashboard-power/overview
           actions:
             - action: "URI"
               title: "Open Power Dashboard"

--- a/home-assistant-amb/config/automation/window_heat_alerts.yaml
+++ b/home-assistant-amb/config/automation/window_heat_alerts.yaml
@@ -49,7 +49,11 @@
                   Today's remaining forecast reaches {{ forecast_max | float | round(1) }}°C.
                   Window guidance is active for all floors.
                 data:
-                  url: /dashboard-climate/inside-vs-outside
+                  clickAction: /dashboard-climate/inside-vs-outside
+                  actions:
+                    - action: "URI"
+                      title: "Open Climate"
+                      uri: "/dashboard-climate/inside-vs-outside"
   mode: single
 
 - id: window_heat_alert_ground_floor

--- a/home-assistant-amb/config/automation/window_heat_alerts.yaml
+++ b/home-assistant-amb/config/automation/window_heat_alerts.yaml
@@ -49,7 +49,7 @@
                   Today's remaining forecast reaches {{ forecast_max | float | round(1) }}°C.
                   Window guidance is active for all floors.
                 data:
-                  clickAction: /dashboard-climate/inside-vs-outside
+                  url: /dashboard-climate/inside-vs-outside
                   actions:
                     - action: "URI"
                       title: "Open Climate"

--- a/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
@@ -91,7 +91,11 @@ action:
               message: >-
                 It is now warmer outside ({{ states(outdoor_temperature_sensor) | float | round(1) }}°C) than on the {{ floor_name | lower }}.
               data:
-                url: /dashboard-climate/inside-vs-outside
+                clickAction: /dashboard-climate/inside-vs-outside
+                actions:
+                  - action: "URI"
+                    title: "Open Climate"
+                    uri: "/dashboard-climate/inside-vs-outside"
           - service: input_boolean.turn_on
             target:
               entity_id: !input close_sent_helper
@@ -112,7 +116,11 @@ action:
               message: >-
                 It is now warmer outside ({{ states(outdoor_temperature_sensor) | float | round(1) }}°C) than on the {{ floor_name | lower }}.
               data:
-                url: /dashboard-climate/inside-vs-outside
+                clickAction: /dashboard-climate/inside-vs-outside
+                actions:
+                  - action: "URI"
+                    title: "Open Climate"
+                    uri: "/dashboard-climate/inside-vs-outside"
           - service: input_boolean.turn_on
             target:
               entity_id: !input close_sent_helper
@@ -133,7 +141,11 @@ action:
               message: >-
                 It is now cooler outside ({{ states(outdoor_temperature_sensor) | float | round(1) }}°C) than on the {{ floor_name | lower }}.
               data:
-                url: /dashboard-climate/inside-vs-outside
+                clickAction: /dashboard-climate/inside-vs-outside
+                actions:
+                  - action: "URI"
+                    title: "Open Climate"
+                    uri: "/dashboard-climate/inside-vs-outside"
           - service: input_boolean.turn_on
             target:
               entity_id: !input open_sent_helper

--- a/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
+++ b/home-assistant-amb/config/blueprints/automation/custom/window_heat_alert.yaml
@@ -91,7 +91,7 @@ action:
               message: >-
                 It is now warmer outside ({{ states(outdoor_temperature_sensor) | float | round(1) }}°C) than on the {{ floor_name | lower }}.
               data:
-                clickAction: /dashboard-climate/inside-vs-outside
+                url: /dashboard-climate/inside-vs-outside
                 actions:
                   - action: "URI"
                     title: "Open Climate"
@@ -116,7 +116,7 @@ action:
               message: >-
                 It is now warmer outside ({{ states(outdoor_temperature_sensor) | float | round(1) }}°C) than on the {{ floor_name | lower }}.
               data:
-                clickAction: /dashboard-climate/inside-vs-outside
+                url: /dashboard-climate/inside-vs-outside
                 actions:
                   - action: "URI"
                     title: "Open Climate"
@@ -141,7 +141,7 @@ action:
               message: >-
                 It is now cooler outside ({{ states(outdoor_temperature_sensor) | float | round(1) }}°C) than on the {{ floor_name | lower }}.
               data:
-                clickAction: /dashboard-climate/inside-vs-outside
+                url: /dashboard-climate/inside-vs-outside
                 actions:
                   - action: "URI"
                     title: "Open Climate"


### PR DESCRIPTION
Replace legacy `url` field with `clickAction` and `actions` for Fridge, Electricity overload, and Window heat alerts. Tapping the notification body or the explicit button now opens the relevant dashboard.

Files changed:
- `fridge.yaml` — opens `/dashboard-power/appliances`
- `power.yaml` — opens `/dashboard-power/overview`
- `window_heat_alerts.yaml` — daily activation opens `/dashboard-climate/inside-vs-outside`
- `window_heat_alert.yaml` blueprint — all floor-level notifications open `/dashboard-climate/inside-vs-outside`